### PR TITLE
EDM-5207 : Reset device labels in E2E helper

### DIFF
--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -910,10 +910,6 @@ func (h *Harness) GetDevice(deviceId string) (*v1beta1.Device, error) {
 
 func (h *Harness) SetLabelsForDevice(deviceId string, labels map[string]string) error {
 	return h.UpdateDeviceWithRetries(deviceId, func(device *v1beta1.Device) {
-		if len(labels) == 0 {
-			device.Metadata.Labels = nil
-			return
-		}
 		devLabels := make(map[string]string, len(labels)+1)
 		devLabels["test-id"] = h.GetTestIDFromContext()
 		for key, value := range labels {


### PR DESCRIPTION
## Summary
- keep the E2E test-id label when SetLabelsForDevice is called with nil/empty labels
- ensure reset calls remove fleet-selector labels instead of sending nil labels that ReplaceDevice preserves

This fixes the E2E helper so “reset labels” actually removes the fleet labels from the device.
Before, SetLabelsForDevice(deviceID, nil) set labels to nil, but the API preserves nil labels on replace, so old labels stayed. The test then kept matching both fleets and timed out waiting for MultipleOwners to clear.
Now the helper keeps only the test-id label, removing the fleet selector labels while preserving cleanup.

## Release target
release-1.3
Target release: release-1.3