### PR TITLE
EDM-5223: Hold rollout behind PrepareDeltas and resume once

### DIFF
--- a/internal/delta_worker/consumer.go
+++ b/internal/delta_worker/consumer.go
@@ -69,6 +69,7 @@ func newPipeline(cfg *config.Config, store deltastore.Store, preparer *Preparer)
 	}
 	if preparer != nil {
 		p.prepare = preparer.Prepare
+		p.preparer = preparer
 	}
 	return p
 }

--- a/internal/delta_worker/pipeline.go
+++ b/internal/delta_worker/pipeline.go
@@ -198,5 +198,5 @@ func (p *pipeline) runResume(ctx context.Context, key deltastore.GenerationKey) 
 	if p.preparer == nil {
 		return nil
 	}
-	return p.preparer.completeWaitingIfTerminal(ctx, key)
+	return p.preparer.CompleteWaitingIfTerminal(ctx, key)
 }

--- a/internal/delta_worker/pipeline.go
+++ b/internal/delta_worker/pipeline.go
@@ -35,7 +35,6 @@ type generationStore interface {
 	InsertGenerations(ctx context.Context, gens []*model.DeltaGeneration) ([]deltastore.GenerationKey, error)
 	ClaimGeneration(ctx context.Context, key deltastore.GenerationKey) (*model.DeltaGeneration, error)
 	CASGeneration(ctx context.Context, key deltastore.GenerationKey, expectedRV int64, update deltastore.GenerationCAS) error
-	ListWaitingPreparesByGeneration(ctx context.Context, key deltastore.GenerationKey) ([]model.DeltaPrepare, error)
 }
 
 type pipeline struct {
@@ -44,8 +43,8 @@ type pipeline struct {
 	check    func(ctx context.Context, imageRepository, sourceDigest, targetDigest string) (existenceResult, error)
 	generate func(ctx context.Context, sourceRef, targetRef, pushPath string) (deltaRef string, sizeBytes int64, err error)
 	pushPath func(imageRepository string) (string, error)
-	resume   func(ctx context.Context, key deltastore.GenerationKey) error
 	prepare  func(ctx context.Context, ev worker_client.EventWithOrgId) error
+	preparer *Preparer
 }
 
 func parseGenerationJob(ev worker_client.EventWithOrgId) (generationJob, bool, error) {
@@ -196,13 +195,8 @@ func (p *pipeline) failGeneration(ctx context.Context, key deltastore.Generation
 }
 
 func (p *pipeline) runResume(ctx context.Context, key deltastore.GenerationKey) error {
-	if p.resume != nil {
-		return p.resume(ctx, key)
+	if p.preparer == nil {
+		return nil
 	}
-	return tryLastPairResume(ctx, p.store, key)
-}
-
-func tryLastPairResume(ctx context.Context, store generationStore, key deltastore.GenerationKey) error {
-	_, err := store.ListWaitingPreparesByGeneration(ctx, key)
-	return err
+	return p.preparer.completeWaitingIfTerminal(ctx, key)
 }

--- a/internal/delta_worker/pipeline_test.go
+++ b/internal/delta_worker/pipeline_test.go
@@ -13,21 +13,20 @@ import (
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 type fakeGenerationStore struct {
-	rejected     []*model.DeltaGeneration
-	inserted     []*model.DeltaGeneration
-	claimed      int
-	claimErr     error
-	cas          []deltastore.GenerationCAS
-	casErr       error
-	casFailN     int
-	waiting      []model.DeltaPrepare
-	claimedRV    int64
-	listWaitingN int
+	rejected  []*model.DeltaGeneration
+	inserted  []*model.DeltaGeneration
+	claimed   int
+	claimErr  error
+	cas       []deltastore.GenerationCAS
+	casErr    error
+	casFailN  int
+	claimedRV int64
 }
 
 func (f *fakeGenerationStore) InsertRejectedGeneration(_ context.Context, gen *model.DeltaGeneration) error {
@@ -61,11 +60,6 @@ func (f *fakeGenerationStore) CASGeneration(ctx context.Context, _ deltastore.Ge
 	}
 	f.cas = append(f.cas, update)
 	return nil
-}
-
-func (f *fakeGenerationStore) ListWaitingPreparesByGeneration(_ context.Context, _ deltastore.GenerationKey) ([]model.DeltaPrepare, error) {
-	f.listWaitingN++
-	return f.waiting, nil
 }
 
 func generateEvent(org uuid.UUID, repo, src, tgt string) worker_client.EventWithOrgId {
@@ -145,7 +139,7 @@ func TestPipelineProcess(t *testing.T) {
 
 	t.Run("When existence is found it should insert rejected and not generate", func(t *testing.T) {
 		req := require.New(t)
-		store := &fakeGenerationStore{waiting: []model.DeltaPrepare{{Name: "fleet-a"}}}
+		store := &fakeGenerationStore{}
 		var generated bool
 		p := &pipeline{
 			store:   store,
@@ -162,7 +156,6 @@ func TestPipelineProcess(t *testing.T) {
 		req.False(generated)
 		req.Len(store.rejected, 1)
 		req.Equal(int64(77), *store.rejected[0].SizeBytes)
-		req.Equal(1, store.listWaitingN)
 		req.Empty(store.inserted)
 	})
 
@@ -209,7 +202,6 @@ func TestPipelineProcess(t *testing.T) {
 		req.Equal(model.DeltaGenerationSucceeded, store.cas[0].Status)
 		req.Equal("write.example/os@sha256:delta", *store.cas[0].DeltaRef)
 		req.Equal(int64(12), *store.cas[0].SizeBytes)
-		req.Equal(1, store.listWaitingN)
 	})
 
 	t.Run("When generate fails it should CAS failed and resume", func(t *testing.T) {
@@ -228,7 +220,6 @@ func TestPipelineProcess(t *testing.T) {
 		req.NoError(p.process(context.Background(), generateEvent(org, repo, src, tgt), log))
 		req.Len(store.cas, 1)
 		req.Equal(model.DeltaGenerationFailed, store.cas[0].Status)
-		req.Equal(1, store.listWaitingN)
 	})
 
 	t.Run("When claim is in_progress it should not steal", func(t *testing.T) {
@@ -265,7 +256,6 @@ func TestPipelineProcess(t *testing.T) {
 		req.NoError(p.process(context.Background(), generateEvent(org, repo, src, tgt), log))
 		req.Len(store.cas, 1)
 		req.Equal(model.DeltaGenerationFailed, store.cas[0].Status)
-		req.Equal(1, store.listWaitingN)
 	})
 
 	t.Run("When generate context times out it should CAS failed", func(t *testing.T) {
@@ -285,7 +275,6 @@ func TestPipelineProcess(t *testing.T) {
 		req.NoError(p.process(context.Background(), generateEvent(org, repo, src, tgt), log))
 		req.Len(store.cas, 1)
 		req.Equal(model.DeltaGenerationFailed, store.cas[0].Status)
-		req.Equal(1, store.listWaitingN)
 	})
 
 	t.Run("When CAS is stale it should not overwrite", func(t *testing.T) {
@@ -302,6 +291,31 @@ func TestPipelineProcess(t *testing.T) {
 			},
 		}
 		req.NoError(p.process(context.Background(), generateEvent(org, repo, src, tgt), log))
-		req.Equal(0, store.listWaitingN)
+		req.Empty(store.cas)
+	})
+
+	t.Run("When generate succeeds and every joined pair is terminal it should complete the waiting prepare", func(t *testing.T) {
+		req := require.New(t)
+		genStore := &fakeGenerationStore{claimedRV: 1}
+		prepStore := newFakePrepareStore()
+		key := deltastore.GenerationKey{OrgID: org, ImageRepository: repo, SourceDigest: src, TargetDigest: tgt}
+		waiting := prepStore.seedWaiting(org, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		req.NoError(prepStore.InsertPrepareGenerations(context.Background(), waiting.ID, []deltastore.GenerationKey{key}))
+		prepStore.generations[key] = &model.DeltaGeneration{Status: model.DeltaGenerationSucceeded}
+		preparer := newTestPreparer(t, prepStore, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
+		p := &pipeline{
+			store:    genStore,
+			timeout:  time.Minute,
+			preparer: preparer,
+			check: func(context.Context, string, string, string) (existenceResult, error) {
+				return existenceResult{Status: existenceNotFound}, nil
+			},
+			generate: func(context.Context, string, string, string) (string, int64, error) {
+				return "ref", 1, nil
+			},
+		}
+		req.NoError(p.process(context.Background(), generateEvent(org, repo, src, tgt), log))
+		req.Equal(model.DeltaPrepareComplete, prepStore.prepares[waiting.ID].Status)
+		req.Contains(resumeEventReasons(preparer), domain.EventReasonFleetRolloutStarted)
 	})
 }

--- a/internal/delta_worker/prepare.go
+++ b/internal/delta_worker/prepare.go
@@ -5,14 +5,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	eventservice "github.com/flightctl/flightctl/internal/service/events"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 )
 
 type prepareStore interface {
@@ -38,6 +44,9 @@ type Preparer struct {
 	JobTimeout func(fleet *domain.Fleet) time.Duration
 	Status     PreparingStatus
 	Resume     func(ctx context.Context, ev worker_client.EventWithOrgId) error
+	Events     eventservice.Service
+	FleetSvc   fleetservice.Service
+	DeviceSvc  deviceservice.Service
 }
 
 type prepareIdentity struct {
@@ -187,7 +196,7 @@ func (p *Preparer) finishSkip(ctx context.Context, ev worker_client.EventWithOrg
 	if err := p.clearStatus(ctx, orgId, kind, name); err != nil {
 		return err
 	}
-	return p.resume(ctx, ev)
+	return p.emitResume(ctx, orgId, kind, name, nil)
 }
 
 func (p *Preparer) failWaiting(ctx context.Context, waiting *model.DeltaPrepare, orgId uuid.UUID, kind, name string) error {
@@ -301,10 +310,110 @@ func (p *Preparer) completeNow(ctx context.Context, ev worker_client.EventWithOr
 		}
 		return err
 	}
+	matches, err := p.identityMatches(ctx, ev, prep)
+	if err != nil {
+		return err
+	}
+	if !matches {
+		return nil
+	}
 	if err := p.clearStatus(ctx, orgId, kind, name); err != nil {
 		return err
 	}
-	return p.resume(ctx, ev)
+	return p.emitResume(ctx, orgId, kind, name, prep)
+}
+
+func (p *Preparer) identityMatches(ctx context.Context, ev worker_client.EventWithOrgId, prep *model.DeltaPrepare) (bool, error) {
+	switch prep.Kind {
+	case domain.FleetKind:
+		fleet, err := p.getFleet(ctx, prep.OrgID, prep.Name)
+		if err != nil {
+			return false, err
+		}
+		live := liveFleetTemplateVersion(fleet, eventTemplateVersion(ev))
+		return equalStringPtr(prep.TemplateVersion, live), nil
+	case domain.DeviceKind:
+		device, err := p.getDevice(ctx, prep.OrgID, prep.Name)
+		if err != nil {
+			return false, err
+		}
+		return equalInt64Ptr(prep.SpecResourceVersion, device.Metadata.Generation), nil
+	default:
+		return false, fmt.Errorf("unsupported prepare kind %q", prep.Kind)
+	}
+}
+
+func (p *Preparer) getFleet(ctx context.Context, orgId uuid.UUID, name string) (*domain.Fleet, error) {
+	if p.FleetSvc == nil {
+		return nil, fmt.Errorf("fleet service is required to resume fleet prepare")
+	}
+	fleet, status := p.FleetSvc.GetFleet(ctx, orgId, name, domain.GetFleetParams{})
+	if status.Code != http.StatusOK {
+		return nil, fmt.Errorf("getting fleet %s: %s", name, status.Message)
+	}
+	return fleet, nil
+}
+
+func (p *Preparer) getDevice(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, error) {
+	if p.DeviceSvc == nil {
+		return nil, fmt.Errorf("device service is required to resume device prepare")
+	}
+	device, status := p.DeviceSvc.GetDevice(ctx, orgId, name)
+	if status.Code != http.StatusOK {
+		return nil, fmt.Errorf("getting device %s: %s", name, status.Message)
+	}
+	return device, nil
+}
+
+func (p *Preparer) emitResume(ctx context.Context, orgId uuid.UUID, kind, name string, prep *model.DeltaPrepare) error {
+	switch kind {
+	case domain.FleetKind:
+		return p.emitFleetResume(ctx, orgId, name, prep)
+	case domain.DeviceKind:
+		if p.Events == nil {
+			return fmt.Errorf("events service is required to resume device prepare")
+		}
+		p.Events.CreateEvent(ctx, orgId, domain.GetBaseEvent(ctx, domain.DeviceKind, name, domain.EventReasonDeltaGenerationCompleted, "Delta generation completed.", nil))
+		return nil
+	default:
+		return fmt.Errorf("unsupported prepare kind %q", kind)
+	}
+}
+
+func (p *Preparer) emitFleetResume(ctx context.Context, orgId uuid.UUID, name string, prep *model.DeltaPrepare) error {
+	if p.Events == nil {
+		return fmt.Errorf("events service is required to resume fleet prepare")
+	}
+	if p.DeviceSvc == nil {
+		return fmt.Errorf("device service is required to resume fleet prepare")
+	}
+	fleet, err := p.getFleet(ctx, orgId, name)
+	if err != nil {
+		return err
+	}
+	tv := lo.FromPtr(prepTemplateVersion(prep))
+	if tv == "" {
+		tv = lo.FromPtr(liveFleetTemplateVersion(fleet, nil))
+	}
+	status := p.FleetSvc.UpdateFleetAnnotations(ctx, orgId, name, map[string]string{
+		domain.FleetAnnotationTemplateVersion: tv,
+	}, nil)
+	if status.Code != http.StatusOK {
+		return fmt.Errorf("setting fleet template version annotation: %s", status.Message)
+	}
+	if err := p.DeviceSvc.SetOutOfDate(ctx, orgId, util.ResourceOwner(domain.FleetKind, name)); err != nil {
+		return err
+	}
+	immediate := fleet.Spec.RolloutPolicy == nil || fleet.Spec.RolloutPolicy.DeviceSelection == nil
+	fleetservice.EmitFleetRolloutStartedEvent(ctx, p.Events, orgId, tv, name, immediate)
+	return nil
+}
+
+func prepTemplateVersion(prep *model.DeltaPrepare) *string {
+	if prep == nil {
+		return nil
+	}
+	return prep.TemplateVersion
 }
 
 func (p *Preparer) setPreparing(ctx context.Context, orgId uuid.UUID, kind, name string, completed, total int) error {
@@ -319,13 +428,6 @@ func (p *Preparer) clearStatus(ctx context.Context, orgId uuid.UUID, kind, name 
 		return nil
 	}
 	return p.Status.Clear(ctx, orgId, kind, name)
-}
-
-func (p *Preparer) resume(ctx context.Context, ev worker_client.EventWithOrgId) error {
-	if p.Resume == nil {
-		return nil
-	}
-	return p.Resume(ctx, ev)
 }
 
 func (p *Preparer) now() time.Time {

--- a/internal/delta_worker/prepare.go
+++ b/internal/delta_worker/prepare.go
@@ -81,7 +81,7 @@ func (p *Preparer) Prepare(ctx context.Context, ev worker_client.EventWithOrgId)
 		return err
 	}
 	if result.Skip {
-		return p.finishSkip(ctx, ev, ev.OrgId, kind, name)
+		return p.finishSkip(ctx, ev, ev.OrgId, kind, name, identity)
 	}
 
 	prep, err := p.waitingOrInsert(ctx, ev.OrgId, kind, name, identity, fleet)
@@ -175,7 +175,28 @@ func (p *Preparer) fleetIdentity(ctx context.Context, ev worker_client.EventWith
 	if err != nil {
 		return prepareIdentity{}, nil, err
 	}
-	return prepareIdentity{templateVersion: liveFleetTemplateVersion(fleet, eventTemplateVersion(ev))}, fleet, nil
+	tv, err := p.fleetPrepareTemplateVersion(ctx, ev)
+	if err != nil {
+		return prepareIdentity{}, nil, err
+	}
+	return prepareIdentity{templateVersion: tv}, fleet, nil
+}
+
+func (p *Preparer) fleetPrepareTemplateVersion(ctx context.Context, ev worker_client.EventWithOrgId) (*string, error) {
+	if tv := eventTemplateVersion(ev); tv != nil {
+		return tv, nil
+	}
+	if p.TVSvc == nil {
+		return nil, fmt.Errorf("template version service is required to identify fleet prepare")
+	}
+	latest, status := p.TVSvc.GetLatestTemplateVersion(ctx, ev.OrgId, ev.Event.InvolvedObject.Name)
+	if status.Code != http.StatusOK {
+		if status.Code == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("getting latest template version for fleet %s: %s", ev.Event.InvolvedObject.Name, status.Message)
+	}
+	return latest.Metadata.Name, nil
 }
 
 func (p *Preparer) deviceIdentity(ctx context.Context, ev worker_client.EventWithOrgId) (prepareIdentity, error) {
@@ -219,7 +240,7 @@ func (p *Preparer) waitingOrInsert(ctx context.Context, orgId uuid.UUID, kind, n
 	return existing, nil
 }
 
-func (p *Preparer) finishSkip(ctx context.Context, ev worker_client.EventWithOrgId, orgId uuid.UUID, kind, name string) error {
+func (p *Preparer) finishSkip(ctx context.Context, ev worker_client.EventWithOrgId, orgId uuid.UUID, kind, name string, identity prepareIdentity) error {
 	waiting, err := p.Store.GetWaitingPrepare(ctx, orgId, kind, name)
 	if err != nil {
 		return err
@@ -232,7 +253,7 @@ func (p *Preparer) finishSkip(ctx context.Context, ev worker_client.EventWithOrg
 	if err := p.clearStatus(ctx, orgId, kind, name); err != nil {
 		return err
 	}
-	return p.emitResume(ctx, orgId, kind, name, nil)
+	return p.emitResume(ctx, orgId, kind, name, &model.DeltaPrepare{TemplateVersion: identity.templateVersion})
 }
 
 func (p *Preparer) failWaiting(ctx context.Context, waiting *model.DeltaPrepare, orgId uuid.UUID, kind, name string) error {
@@ -374,9 +395,15 @@ func (p *Preparer) identityMatches(ctx context.Context, _ worker_client.EventWit
 		}
 		return equalStringPtr(prep.TemplateVersion, tv.Metadata.Name), nil
 	case domain.DeviceKind:
-		device, err := p.getDevice(ctx, prep.OrgID, prep.Name)
-		if err != nil {
-			return false, err
+		if p.DeviceSvc == nil {
+			return false, fmt.Errorf("device service is required to resume device prepare")
+		}
+		device, status := p.DeviceSvc.GetDevice(ctx, prep.OrgID, prep.Name)
+		if status.Code != http.StatusOK {
+			if status.Code == http.StatusNotFound {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting device %s: %s", prep.Name, status.Message)
 		}
 		return equalInt64Ptr(prep.SpecResourceVersion, device.Metadata.Generation), nil
 	default:
@@ -393,17 +420,6 @@ func (p *Preparer) getFleet(ctx context.Context, orgId uuid.UUID, name string) (
 		return nil, fmt.Errorf("getting fleet %s: %s", name, status.Message)
 	}
 	return fleet, nil
-}
-
-func (p *Preparer) getDevice(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, error) {
-	if p.DeviceSvc == nil {
-		return nil, fmt.Errorf("device service is required to resume device prepare")
-	}
-	device, status := p.DeviceSvc.GetDevice(ctx, orgId, name)
-	if status.Code != http.StatusOK {
-		return nil, fmt.Errorf("getting device %s: %s", name, status.Message)
-	}
-	return device, nil
 }
 
 func (p *Preparer) emitResume(ctx context.Context, orgId uuid.UUID, kind, name string, prep *model.DeltaPrepare) error {

--- a/internal/delta_worker/prepare.go
+++ b/internal/delta_worker/prepare.go
@@ -13,6 +13,7 @@ import (
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	eventservice "github.com/flightctl/flightctl/internal/service/events"
 	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/util"
@@ -49,6 +50,7 @@ type Preparer struct {
 	Events     eventservice.Service
 	FleetSvc   fleetservice.Service
 	DeviceSvc  deviceservice.Service
+	TVSvc      templateversionservice.Service
 }
 
 type prepareIdentity struct {
@@ -357,15 +359,20 @@ func (p *Preparer) completeNow(ctx context.Context, ev worker_client.EventWithOr
 	return p.emitResume(ctx, orgId, kind, name, prep)
 }
 
-func (p *Preparer) identityMatches(ctx context.Context, ev worker_client.EventWithOrgId, prep *model.DeltaPrepare) (bool, error) {
+func (p *Preparer) identityMatches(ctx context.Context, _ worker_client.EventWithOrgId, prep *model.DeltaPrepare) (bool, error) {
 	switch prep.Kind {
 	case domain.FleetKind:
-		fleet, err := p.getFleet(ctx, prep.OrgID, prep.Name)
-		if err != nil {
-			return false, err
+		if p.TVSvc == nil {
+			return false, fmt.Errorf("template version service is required to resume fleet prepare")
 		}
-		live := liveFleetTemplateVersion(fleet, eventTemplateVersion(ev))
-		return equalStringPtr(prep.TemplateVersion, live), nil
+		tv, status := p.TVSvc.GetLatestTemplateVersion(ctx, prep.OrgID, prep.Name)
+		if status.Code != http.StatusOK {
+			if status.Code == http.StatusNotFound {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting latest template version for fleet %s: %s", prep.Name, status.Message)
+		}
+		return equalStringPtr(prep.TemplateVersion, tv.Metadata.Name), nil
 	case domain.DeviceKind:
 		device, err := p.getDevice(ctx, prep.OrgID, prep.Name)
 		if err != nil {

--- a/internal/delta_worker/prepare.go
+++ b/internal/delta_worker/prepare.go
@@ -123,7 +123,7 @@ func (p *Preparer) Prepare(ctx context.Context, ev worker_client.EventWithOrgId)
 	return p.setPreparing(ctx, ev.OrgId, kind, name, completed, len(keys))
 }
 
-func (p *Preparer) completeWaitingIfTerminal(ctx context.Context, key deltastore.GenerationKey) error {
+func (p *Preparer) CompleteWaitingIfTerminal(ctx context.Context, key deltastore.GenerationKey) error {
 	if p.Store == nil {
 		return fmt.Errorf("store is required")
 	}

--- a/internal/delta_worker/prepare.go
+++ b/internal/delta_worker/prepare.go
@@ -28,6 +28,8 @@ type prepareStore interface {
 	InsertGenerations(ctx context.Context, gens []*model.DeltaGeneration) ([]deltastore.GenerationKey, error)
 	InsertPrepareGenerations(ctx context.Context, prepareID uuid.UUID, keys []deltastore.GenerationKey) error
 	GetGeneration(ctx context.Context, key deltastore.GenerationKey) (*model.DeltaGeneration, error)
+	ListWaitingPreparesByGeneration(ctx context.Context, key deltastore.GenerationKey) ([]model.DeltaPrepare, error)
+	ListPrepareGenerationKeys(ctx context.Context, prepareID uuid.UUID) ([]deltastore.GenerationKey, error)
 }
 
 type PreparingStatus interface {
@@ -117,6 +119,38 @@ func (p *Preparer) Prepare(ctx context.Context, ev worker_client.EventWithOrgId)
 		return p.completeNow(ctx, ev, prep, ev.OrgId, kind, name)
 	}
 	return p.setPreparing(ctx, ev.OrgId, kind, name, completed, len(keys))
+}
+
+func (p *Preparer) completeWaitingIfTerminal(ctx context.Context, key deltastore.GenerationKey) error {
+	if p.Store == nil {
+		return fmt.Errorf("store is required")
+	}
+	waiting, err := p.Store.ListWaitingPreparesByGeneration(ctx, key)
+	if err != nil {
+		return err
+	}
+	for i := range waiting {
+		prep := &waiting[i]
+		keys, err := p.Store.ListPrepareGenerationKeys(ctx, prep.ID)
+		if err != nil {
+			return err
+		}
+		allTerminal, _, err := p.completedCount(ctx, keys)
+		if err != nil {
+			return err
+		}
+		if !allTerminal {
+			continue
+		}
+		ev := worker_client.EventWithOrgId{
+			OrgId: prep.OrgID,
+			Event: domain.Event{InvolvedObject: domain.ObjectReference{Kind: prep.Kind, Name: prep.Name}},
+		}
+		if err := p.completeNow(ctx, ev, prep, prep.OrgID, prep.Kind, prep.Name); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (p *Preparer) liveIdentity(ctx context.Context, ev worker_client.EventWithOrgId) (prepareIdentity, *domain.Fleet, error) {

--- a/internal/delta_worker/prepare_test.go
+++ b/internal/delta_worker/prepare_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flightctl/flightctl/internal/flterrors"
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/tasks"
@@ -1045,6 +1046,7 @@ func newTestPreparer(t *testing.T, store *fakePrepareStore, resolver *Resolver, 
 	ctrl := gomock.NewController(t)
 	fleetSvc := fleetservice.NewMockService(ctrl)
 	deviceSvc := deviceservice.NewMockService(ctrl)
+	tvSvc := templateversionservice.NewMockService(ctrl)
 	if resolver != nil && resolver.Fleet != nil {
 		fleetSvc.EXPECT().GetFleet(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(ctx context.Context, orgId uuid.UUID, name string, _ domain.GetFleetParams) (*domain.Fleet, domain.Status) {
@@ -1053,6 +1055,19 @@ func newTestPreparer(t *testing.T, store *fakePrepareStore, resolver *Resolver, 
 					return nil, domain.StatusInternalServerError(err.Error())
 				}
 				return fleet, domain.StatusOK()
+			},
+		).AnyTimes()
+		tvSvc.EXPECT().GetLatestTemplateVersion(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, orgId uuid.UUID, name string) (*domain.TemplateVersion, domain.Status) {
+				fleet, err := resolver.Fleet(ctx, orgId, name)
+				if err != nil {
+					return nil, domain.StatusInternalServerError(err.Error())
+				}
+				tv := liveFleetTemplateVersion(fleet, nil)
+				if tv == nil {
+					return nil, domain.StatusResourceNotFound("TemplateVersion", name)
+				}
+				return &domain.TemplateVersion{Metadata: domain.ObjectMeta{Name: tv}}, domain.StatusOK()
 			},
 		).AnyTimes()
 	}
@@ -1083,6 +1098,7 @@ func newTestPreparer(t *testing.T, store *fakePrepareStore, resolver *Resolver, 
 		Events:    rec,
 		FleetSvc:  fleetSvc,
 		DeviceSvc: deviceSvc,
+		TVSvc:     tvSvc,
 	}
 	if emit != nil {
 		p.Emit = emit.emit

--- a/internal/delta_worker/prepare_test.go
+++ b/internal/delta_worker/prepare_test.go
@@ -493,10 +493,10 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		status := &statusSpy{}
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
-		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-11"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-10"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
 		p.Now = func() time.Time { return now }
 
-		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-10"))
+		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-11"))
 		require.NoError(t, err)
 		gotOld, ok := store.prepares[old.ID]
 		require.True(t, ok)
@@ -518,15 +518,29 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		assert.NotEqual(t, domain.EventReasonDeltaGenerationCompleted, emit.events[0].Reason)
 	})
 
+	t.Run("When the fleet annotation is an older TV it should key the wait to the PrepareDeltas templateVersion", func(t *testing.T) {
+		store := newFakePrepareStore()
+		emit := &emitSpy{}
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, emit)
+
+		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-2"))
+		require.NoError(t, err)
+		require.Len(t, store.prepares, 1)
+		assert.Equal(t, "tv-2", lo.FromPtr(firstPrepare(store).TemplateVersion))
+		assert.Equal(t, model.DeltaPrepareWaiting, firstPrepare(store).Status)
+		require.Len(t, emit.events, 1)
+		assert.Equal(t, domain.EventReasonGenerateDelta, emit.events[0].Reason)
+	})
+
 	t.Run("When supercede CAS loses it should not clear preparing status", func(t *testing.T) {
 		store := newFakePrepareStore()
 		store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-10"), nil, now.Add(-time.Hour))
 		store.casErr = flterrors.ErrNoRowsUpdated
 		status := &statusSpy{}
-		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-11"), deviceWithOS("d1", true, prepareTestSrc)), status, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-10"), deviceWithOS("d1", true, prepareTestSrc)), status, &resumeSpy{}, &emitSpy{})
 		p.Now = func() time.Time { return now }
 
-		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-10"))
+		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-11"))
 		require.NoError(t, err)
 		assert.Empty(t, status.clears)
 	})

--- a/internal/delta_worker/prepare_test.go
+++ b/internal/delta_worker/prepare_test.go
@@ -9,14 +9,18 @@ import (
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
 )
 
 const (
@@ -34,11 +38,11 @@ func TestPrepare_SkipPaths(t *testing.T) {
 		store := newFakePrepareStore()
 		status := &statusSpy{}
 		resume := &resumeSpy{}
-		p := newTestPreparer(store, skipGenerateDeltaResolver(), status, resume, nil)
+		p := newTestPreparer(t, store, skipGenerateDeltaResolver(), status, resume, nil)
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
 		assert.Empty(t, store.prepares)
-		assert.Equal(t, 1, resume.n)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		assert.Empty(t, status.sets)
 		require.Len(t, status.clears, 1)
 		assert.Equal(t, domain.FleetKind, status.clears[0].kind)
@@ -48,17 +52,17 @@ func TestPrepare_SkipPaths(t *testing.T) {
 		store := newFakePrepareStore()
 		existing := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
 		resume := &resumeSpy{}
-		p := newTestPreparer(store, skipGenerateDeltaResolver(), &statusSpy{}, resume, nil)
+		p := newTestPreparer(t, store, skipGenerateDeltaResolver(), &statusSpy{}, resume, nil)
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
 		assert.Equal(t, model.DeltaPrepareFailed, store.prepares[existing.ID].Status)
-		assert.Equal(t, 1, resume.n)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 	})
 
 	t.Run("When the write target is missing it should Resume without inserting", func(t *testing.T) {
 		store := newFakePrepareStore()
 		resume := &resumeSpy{}
-		p := newTestPreparer(store, &Resolver{
+		p := newTestPreparer(t, store, &Resolver{
 			Fleet: func(_ context.Context, _ uuid.UUID, _ string) (*domain.Fleet, error) {
 				return fleetWithTV("fleet-1", "tv-1"), nil
 			},
@@ -69,29 +73,151 @@ func TestPrepare_SkipPaths(t *testing.T) {
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
 		assert.Empty(t, store.prepares)
-		assert.Equal(t, 1, resume.n)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 	})
 
 	t.Run("When no device is eligible it should Resume without inserting", func(t *testing.T) {
 		store := newFakePrepareStore()
 		resume := &resumeSpy{}
 		fleet := fleetWithTV("fleet-1", "tv-1")
-		p := newTestPreparer(store, eligibleFleetResolver(fleet, deviceWithOS("d1", false, prepareTestSrc)), &statusSpy{}, resume, nil)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet, deviceWithOS("d1", false, prepareTestSrc)), &statusSpy{}, resume, nil)
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
 		assert.Empty(t, store.prepares)
-		assert.Equal(t, 1, resume.n)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 	})
 
 	t.Run("When DeltaCandidates is empty it should Resume without inserting", func(t *testing.T) {
 		store := newFakePrepareStore()
 		resume := &resumeSpy{}
 		fleet := fleetWithTV("fleet-1", "tv-1")
-		p := newTestPreparer(store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, "")), &statusSpy{}, resume, nil)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, "")), &statusSpy{}, resume, nil)
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
 		assert.Empty(t, store.prepares)
-		assert.Equal(t, 1, resume.n)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+	})
+}
+
+func TestCompleteNow(t *testing.T) {
+	orgId := uuid.New()
+	ctx := context.Background()
+
+	t.Run("When CAS wins and live TV matches it should emit FleetRolloutStarted, annotate, SetOutOfDate, and clear preparing", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		status := &statusSpy{}
+		var annotated map[string]string
+		var outOfDateOwner string
+		p := newCompleteNowPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), status, func(ann map[string]string) {
+			annotated = ann
+		}, func(owner string) {
+			outOfDateOwner = owner
+		})
+
+		err := p.completeNow(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"), prep, orgId, domain.FleetKind, "fleet-1")
+		require.NoError(t, err)
+		assert.Equal(t, model.DeltaPrepareComplete, store.prepares[prep.ID].Status)
+		assert.Equal(t, []domain.EventReason{domain.EventReasonFleetRolloutStarted}, resumeEventReasons(p))
+		assert.Equal(t, "tv-1", annotated[domain.FleetAnnotationTemplateVersion])
+		assert.Equal(t, util.ResourceOwner(domain.FleetKind, "fleet-1"), outOfDateOwner)
+		require.Len(t, status.clears, 1)
+		assert.Equal(t, domain.FleetKind, status.clears[0].kind)
+		d, err := recordedEvents(p)[0].Details.AsFleetRolloutStartedDetails()
+		require.NoError(t, err)
+		assert.Equal(t, domain.None, d.RolloutStrategy)
+	})
+
+	t.Run("When live fleet has deviceSelection it should emit batched FleetRolloutStarted", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		fleet := fleetWithTV("fleet-1", "tv-1")
+		fleet.Spec.RolloutPolicy = &domain.RolloutPolicy{DeviceSelection: &domain.RolloutDeviceSelection{}}
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet), &statusSpy{}, &resumeSpy{}, nil)
+
+		err := p.completeNow(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"), prep, orgId, domain.FleetKind, "fleet-1")
+		require.NoError(t, err)
+		d, err := recordedEvents(p)[0].Details.AsFleetRolloutStartedDetails()
+		require.NoError(t, err)
+		assert.Equal(t, domain.Batched, d.RolloutStrategy)
+	})
+
+	t.Run("When CAS wins and live TV is stale it should not emit or clear preparing", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		status := &statusSpy{}
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-2")), status, &resumeSpy{}, nil)
+
+		err := p.completeNow(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-2"), prep, orgId, domain.FleetKind, "fleet-1")
+		require.NoError(t, err)
+		assert.Equal(t, model.DeltaPrepareComplete, store.prepares[prep.ID].Status)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+		assert.Empty(t, status.clears)
+	})
+
+	t.Run("When CAS misses it should not emit", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		require.NoError(t, store.CASPrepareStatus(ctx, prep.ID, model.DeltaPrepareComplete))
+		status := &statusSpy{}
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), status, &resumeSpy{}, nil)
+
+		err := p.completeNow(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"), prep, orgId, domain.FleetKind, "fleet-1")
+		require.NoError(t, err)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+		assert.Empty(t, status.clears)
+	})
+
+	t.Run("When two completeNow calls race it should emit only once", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
+
+		require.NoError(t, p.completeNow(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"), prep, orgId, domain.FleetKind, "fleet-1"))
+		require.NoError(t, p.completeNow(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"), prep, orgId, domain.FleetKind, "fleet-1"))
+		assert.Equal(t, []domain.EventReason{domain.EventReasonFleetRolloutStarted}, resumeEventReasons(p))
+	})
+
+	t.Run("When the prepare is not waiting it should not emit", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		require.NoError(t, store.CASPrepareStatus(ctx, prep.ID, model.DeltaPrepareFailed))
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
+
+		err := p.completeNow(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"), prep, orgId, domain.FleetKind, "fleet-1")
+		require.NoError(t, err)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+	})
+
+	t.Run("When device RV matches it should emit DeltaGenerationCompleted and clear preparing", func(t *testing.T) {
+		store := newFakePrepareStore()
+		rv := int64(7)
+		prep := store.seedWaiting(orgId, domain.DeviceKind, "d1", nil, &rv, time.Now())
+		status := &statusSpy{}
+		device := deviceWithOS("d1", true, prepareTestSrc)
+		device.Metadata.Generation = lo.ToPtr(int64(7))
+		p := newTestPreparer(t, store, eligibleDeviceResolver(device), status, &resumeSpy{}, nil)
+
+		err := p.completeNow(ctx, devicePrepareEvent(orgId, "d1"), prep, orgId, domain.DeviceKind, "d1")
+		require.NoError(t, err)
+		assert.Equal(t, []domain.EventReason{domain.EventReasonDeltaGenerationCompleted}, resumeEventReasons(p))
+		require.Len(t, status.clears, 1)
+		assert.Equal(t, domain.DeviceKind, status.clears[0].kind)
+	})
+
+	t.Run("When device RV is stale it should not emit or clear preparing", func(t *testing.T) {
+		store := newFakePrepareStore()
+		rv := int64(7)
+		prep := store.seedWaiting(orgId, domain.DeviceKind, "d1", nil, &rv, time.Now())
+		status := &statusSpy{}
+		device := deviceWithOS("d1", true, prepareTestSrc)
+		device.Metadata.Generation = lo.ToPtr(int64(8))
+		p := newTestPreparer(t, store, eligibleDeviceResolver(device), status, &resumeSpy{}, nil)
+
+		err := p.completeNow(ctx, devicePrepareEvent(orgId, "d1"), prep, orgId, domain.DeviceKind, "d1")
+		require.NoError(t, err)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonDeltaGenerationCompleted)
+		assert.Empty(t, status.clears)
 	})
 }
 
@@ -106,7 +232,7 @@ func TestPrepare_InsertAndAck(t *testing.T) {
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
 		fleet := fleetWithTV("fleet-1", "tv-1")
-		p := newTestPreparer(store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
 		p.Now = func() time.Time { return now }
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
@@ -128,7 +254,7 @@ func TestPrepare_InsertAndAck(t *testing.T) {
 		assert.Equal(t, prepareTestRepo, payload.ImageRepository)
 		assert.Equal(t, prepareTestSrc, payload.SourceDigest)
 		assert.Equal(t, prepareTestTgt, payload.TargetDigest)
-		assert.Equal(t, 0, resume.n)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		require.Len(t, status.sets, 1)
 		assert.Equal(t, domain.FleetKind, status.sets[0].kind)
 		assert.Equal(t, "fleet-1", status.sets[0].name)
@@ -139,7 +265,7 @@ func TestPrepare_InsertAndAck(t *testing.T) {
 	t.Run("When enqueue fails it should return the emit error after insert", func(t *testing.T) {
 		store := newFakePrepareStore()
 		emit := &emitSpy{err: errors.New("redis down")}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, emit)
 		p.Now = func() time.Time { return now }
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
@@ -152,7 +278,7 @@ func TestPrepare_InsertAndAck(t *testing.T) {
 		store := newFakePrepareStore()
 		emit := &emitSpy{}
 		fleet := fleetWithTV("fleet-1", "tv-1")
-		p := newTestPreparer(store, eligibleFleetResolver(fleet,
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet,
 			deviceWithOS("d1", true, prepareTestSrc),
 			deviceWithOS("d2", true, prepareTestSrc),
 		), &statusSpy{}, &resumeSpy{}, emit)
@@ -169,7 +295,7 @@ func TestPrepare_InsertAndAck(t *testing.T) {
 		store := newFakePrepareStore()
 		fleet := fleetWithTV("fleet-1", "tv-1")
 		fleet.Spec.RolloutPolicy = nil
-		p := newTestPreparer(store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
 		require.Len(t, store.prepares, 1)
@@ -185,7 +311,7 @@ func TestPrepare_Deadlines(t *testing.T) {
 	t.Run("When maxWait is omitted it should persist with a nil deadline", func(t *testing.T) {
 		store := newFakePrepareStore()
 		resume := &resumeSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, resume, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, resume, &emitSpy{})
 		p.Now = func() time.Time { return now }
 		p.MaxWait = func(*domain.Fleet) *time.Duration { return nil }
 
@@ -193,13 +319,13 @@ func TestPrepare_Deadlines(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, firstPrepare(store).Deadline)
 		assert.Equal(t, model.DeltaPrepareWaiting, firstPrepare(store).Status)
-		assert.Equal(t, 0, resume.n)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 	})
 
 	t.Run("When maxWait is set it should set deadline to CreatedAt plus wait", func(t *testing.T) {
 		store := newFakePrepareStore()
 		wait := 5 * time.Minute
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
 		p.Now = func() time.Time { return now }
 		p.MaxWait = func(*domain.Fleet) *time.Duration { return &wait }
 
@@ -216,7 +342,7 @@ func TestPrepare_Deadlines(t *testing.T) {
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
 		zero := time.Duration(0)
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
 		p.Now = func() time.Time { return now }
 		p.MaxWait = func(*domain.Fleet) *time.Duration { return &zero }
 
@@ -225,7 +351,7 @@ func TestPrepare_Deadlines(t *testing.T) {
 		require.Len(t, emit.events, 1)
 		assert.Equal(t, model.DeltaPrepareComplete, firstPrepare(store).Status)
 		assert.Equal(t, now, *firstPrepare(store).Deadline)
-		assert.Equal(t, 1, resume.n)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		assert.Empty(t, status.sets)
 		require.Len(t, status.clears, 1)
 	})
@@ -236,7 +362,7 @@ func TestPrepare_Deadlines(t *testing.T) {
 		fleetWait := domain.Duration("10m")
 		fleet.Spec.RolloutPolicy = &domain.RolloutPolicy{MaxWaitForDelta: &fleetWait}
 		deploy := 30 * time.Minute
-		p := newTestPreparer(store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
 		p.Now = func() time.Time { return now }
 		p.MaxWait = func(f *domain.Fleet) *time.Duration {
 			d, err := maxWaitFromFleet(f, &deploy)
@@ -274,7 +400,7 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		}
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, resume, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, resume, emit)
 		p.Now = func() time.Time { return now }
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
@@ -283,7 +409,7 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		assert.Equal(t, existing.ID, firstPrepare(store).ID)
 		assert.Equal(t, created, firstPrepare(store).CreatedAt)
 		assert.Equal(t, model.DeltaPrepareWaiting, firstPrepare(store).Status)
-		assert.Equal(t, 0, resume.n)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		assert.Empty(t, emit.events)
 	})
 
@@ -292,7 +418,7 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		created := now.Add(-time.Hour)
 		existing := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, created)
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, emit)
 		p.Now = func() time.Time { return now }
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
@@ -310,7 +436,7 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		status := &statusSpy{}
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-11"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-11"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
 		p.Now = func() time.Time { return now }
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-10"))
@@ -328,7 +454,7 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		require.NotNil(t, inserted)
 		assert.Equal(t, model.DeltaPrepareWaiting, inserted.Status)
 		assert.Equal(t, "tv-11", lo.FromPtr(inserted.TemplateVersion))
-		assert.Equal(t, 0, resume.n)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		require.Len(t, emit.events, 1)
 		assert.Equal(t, domain.EventReasonGenerateDelta, emit.events[0].Reason)
 		assert.NotEqual(t, domain.EventReasonFleetRolloutStarted, emit.events[0].Reason)
@@ -340,7 +466,7 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-10"), nil, now.Add(-time.Hour))
 		store.casErr = flterrors.ErrNoRowsUpdated
 		status := &statusSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-11"), deviceWithOS("d1", true, prepareTestSrc)), status, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-11"), deviceWithOS("d1", true, prepareTestSrc)), status, &resumeSpy{}, &emitSpy{})
 		p.Now = func() time.Time { return now }
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-10"))
@@ -353,11 +479,11 @@ func TestPrepare_DedupeAndSupercede(t *testing.T) {
 		store.insertErr = flterrors.ErrDuplicateName
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, resume, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, resume, emit)
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
-		assert.Equal(t, 0, resume.n)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		assert.Empty(t, emit.events)
 		assert.Empty(t, store.prepares)
 	})
@@ -384,13 +510,13 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 		status := &statusSpy{}
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), status, resume, emit)
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
 		assert.Equal(t, 0, store.insertGensN)
 		assert.Empty(t, emit.events)
-		assert.Equal(t, 1, resume.n)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		assert.Equal(t, model.DeltaPrepareComplete, firstPrepare(store).Status)
 		assert.Len(t, store.joins, 1)
 		assert.Empty(t, status.sets)
@@ -413,7 +539,7 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 			Status:          model.DeltaGenerationFailed,
 		}
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, emit)
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1"), deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, emit)
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
@@ -443,7 +569,7 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 		r.Expand = func(_ tasks.RenderedSpec, cands []DeltaCandidate) []DeltaCandidate {
 			return append(cands, DeltaCandidate{ImageRepository: "quay.io/apps/web", CurrentDigest: "sha256:ccc", NewDigest: "sha256:ddd"})
 		}
-		p := newTestPreparer(store, r, status, &resumeSpy{}, emit)
+		p := newTestPreparer(t, store, r, status, &resumeSpy{}, emit)
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
@@ -478,7 +604,7 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 		r.Expand = func(_ tasks.RenderedSpec, cands []DeltaCandidate) []DeltaCandidate {
 			return append(cands, DeltaCandidate{ImageRepository: "quay.io/apps/web", CurrentDigest: "sha256:ccc", NewDigest: "sha256:ddd"})
 		}
-		p := newTestPreparer(store, r, &statusSpy{}, &resumeSpy{}, emit)
+		p := newTestPreparer(t, store, r, &statusSpy{}, &resumeSpy{}, emit)
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-1"))
 		require.NoError(t, err)
@@ -493,7 +619,7 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 		status := &statusSpy{}
 		device := deviceWithOS("d1", true, prepareTestSrc)
 		device.Metadata.Generation = lo.ToPtr(int64(7))
-		p := newTestPreparer(store, eligibleDeviceResolver(device), status, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleDeviceResolver(device), status, &resumeSpy{}, &emitSpy{})
 
 		err := p.Prepare(ctx, devicePrepareEvent(orgId, "d1"))
 		require.NoError(t, err)
@@ -529,13 +655,13 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 		device.Metadata.ResourceVersion = lo.ToPtr("99")
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleDeviceResolver(device), &statusSpy{}, resume, emit)
+		p := newTestPreparer(t, store, eligibleDeviceResolver(device), &statusSpy{}, resume, emit)
 
 		err := p.Prepare(ctx, devicePrepareEvent(orgId, "d1"))
 		require.NoError(t, err)
 		assert.Len(t, store.prepares, 1)
 		assert.Equal(t, existing.ID, firstPrepare(store).ID)
-		assert.Equal(t, 0, resume.n)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		assert.Empty(t, emit.events)
 	})
 
@@ -547,13 +673,13 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 		device.Metadata.Generation = lo.ToPtr(int64(6))
 		resume := &resumeSpy{}
 		emit := &emitSpy{}
-		p := newTestPreparer(store, eligibleDeviceResolver(device), &statusSpy{}, resume, emit)
+		p := newTestPreparer(t, store, eligibleDeviceResolver(device), &statusSpy{}, resume, emit)
 
 		err := p.Prepare(ctx, devicePrepareEvent(orgId, "d1"))
 		require.NoError(t, err)
 		assert.Equal(t, model.DeltaPrepareFailed, store.prepares[old.ID].Status)
 		assert.Len(t, store.prepares, 2)
-		assert.Equal(t, 0, resume.n)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		require.Len(t, emit.events, 1)
 		assert.Equal(t, domain.EventReasonGenerateDelta, emit.events[0].Reason)
 	})
@@ -561,7 +687,7 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 	t.Run("When a fleet annotation is missing it should fall back to event details TemplateVersion", func(t *testing.T) {
 		store := newFakePrepareStore()
 		fleet := &domain.Fleet{Metadata: domain.ObjectMeta{Name: lo.ToPtr("fleet-1")}, Spec: domain.FleetSpec{}}
-		p := newTestPreparer(store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleet, deviceWithOS("d1", true, prepareTestSrc)), &statusSpy{}, &resumeSpy{}, &emitSpy{})
 
 		err := p.Prepare(ctx, fleetPrepareEvent(orgId, "fleet-1", "tv-from-event"))
 		require.NoError(t, err)
@@ -575,7 +701,7 @@ func TestPrepare_TerminalAndDevice(t *testing.T) {
 		var maxWaitFleet *domain.Fleet
 		var jobTimeoutFleet *domain.Fleet
 		deployWait := 15 * time.Minute
-		p := newTestPreparer(store, eligibleDeviceResolver(device), &statusSpy{}, &resumeSpy{}, &emitSpy{})
+		p := newTestPreparer(t, store, eligibleDeviceResolver(device), &statusSpy{}, &resumeSpy{}, &emitSpy{})
 		p.MaxWait = func(f *domain.Fleet) *time.Duration {
 			maxWaitFleet = f
 			return &deployWait
@@ -826,7 +952,36 @@ func (r *resumeSpy) resume(_ context.Context, _ worker_client.EventWithOrgId) er
 	return nil
 }
 
-func newTestPreparer(store *fakePrepareStore, resolver *Resolver, status PreparingStatus, resume *resumeSpy, emit *emitSpy) *Preparer {
+func newTestPreparer(t *testing.T, store *fakePrepareStore, resolver *Resolver, status PreparingStatus, resume *resumeSpy, emit *emitSpy) *Preparer {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	fleetSvc := fleetservice.NewMockService(ctrl)
+	deviceSvc := deviceservice.NewMockService(ctrl)
+	if resolver != nil && resolver.Fleet != nil {
+		fleetSvc.EXPECT().GetFleet(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, orgId uuid.UUID, name string, _ domain.GetFleetParams) (*domain.Fleet, domain.Status) {
+				fleet, err := resolver.Fleet(ctx, orgId, name)
+				if err != nil {
+					return nil, domain.StatusInternalServerError(err.Error())
+				}
+				return fleet, domain.StatusOK()
+			},
+		).AnyTimes()
+	}
+	if resolver != nil && resolver.Device != nil {
+		deviceSvc.EXPECT().GetDevice(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, orgId uuid.UUID, name string) (*domain.Device, domain.Status) {
+				device, err := resolver.Device(ctx, orgId, name)
+				if err != nil {
+					return nil, domain.StatusInternalServerError(err.Error())
+				}
+				return device, domain.StatusOK()
+			},
+		).AnyTimes()
+	}
+	fleetSvc.EXPECT().UpdateFleetAnnotations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(domain.StatusOK()).AnyTimes()
+	deviceSvc.EXPECT().SetOutOfDate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	rec := &eventRecorder{}
 	p := &Preparer{
 		Resolver: resolver,
 		Store:    store,
@@ -835,13 +990,87 @@ func newTestPreparer(store *fakePrepareStore, resolver *Resolver, status Prepari
 		JobTimeout: func(*domain.Fleet) time.Duration {
 			return 30 * time.Minute
 		},
-		Status: status,
-		Resume: resume.resume,
+		Status:    status,
+		Resume:    resume.resume,
+		Events:    rec,
+		FleetSvc:  fleetSvc,
+		DeviceSvc: deviceSvc,
 	}
 	if emit != nil {
 		p.Emit = emit.emit
 	}
 	return p
+}
+
+func newCompleteNowPreparer(t *testing.T, store *fakePrepareStore, resolver *Resolver, status PreparingStatus, onAnnotate func(map[string]string), onOutOfDate func(string)) *Preparer {
+	t.Helper()
+	p := newTestPreparer(t, store, resolver, status, &resumeSpy{}, nil)
+	ctrl := gomock.NewController(t)
+	fleetSvc := fleetservice.NewMockService(ctrl)
+	deviceSvc := deviceservice.NewMockService(ctrl)
+	fleetSvc.EXPECT().GetFleet(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, orgId uuid.UUID, name string, _ domain.GetFleetParams) (*domain.Fleet, domain.Status) {
+			fleet, err := resolver.Fleet(ctx, orgId, name)
+			if err != nil {
+				return nil, domain.StatusInternalServerError(err.Error())
+			}
+			return fleet, domain.StatusOK()
+		},
+	).AnyTimes()
+	fleetSvc.EXPECT().UpdateFleetAnnotations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ uuid.UUID, _ string, annotations map[string]string, _ []string) domain.Status {
+			if onAnnotate != nil {
+				onAnnotate(annotations)
+			}
+			return domain.StatusOK()
+		},
+	)
+	deviceSvc.EXPECT().SetOutOfDate(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ uuid.UUID, owner string) error {
+			if onOutOfDate != nil {
+				onOutOfDate(owner)
+			}
+			return nil
+		},
+	)
+	p.FleetSvc = fleetSvc
+	p.DeviceSvc = deviceSvc
+	return p
+}
+
+func recordedEvents(p *Preparer) []*domain.Event {
+	rec, ok := p.Events.(*eventRecorder)
+	if !ok {
+		return nil
+	}
+	return rec.events
+}
+
+type eventRecorder struct {
+	events []*domain.Event
+}
+
+func (e *eventRecorder) CreateEvent(_ context.Context, _ uuid.UUID, event *domain.Event) {
+	if event == nil {
+		return
+	}
+	cp := *event
+	e.events = append(e.events, &cp)
+}
+
+func (e *eventRecorder) HandleGenericResourceDeletedEvents(context.Context, domain.ResourceKind, uuid.UUID, string, interface{}, interface{}, bool, error) {
+}
+
+func resumeEventReasons(p *Preparer) []domain.EventReason {
+	rec, ok := p.Events.(*eventRecorder)
+	if !ok {
+		return nil
+	}
+	out := make([]domain.EventReason, 0, len(rec.events))
+	for _, ev := range rec.events {
+		out = append(out, ev.Reason)
+	}
+	return out
 }
 
 func firstPrepare(store *fakePrepareStore) *model.DeltaPrepare {

--- a/internal/delta_worker/prepare_test.go
+++ b/internal/delta_worker/prepare_test.go
@@ -221,6 +221,62 @@ func TestCompleteNow(t *testing.T) {
 	})
 }
 
+func TestCompleteWaitingIfTerminal(t *testing.T) {
+	orgId := uuid.New()
+	ctx := context.Background()
+	keyA := deltastore.GenerationKey{OrgID: orgId, ImageRepository: prepareTestRepo, SourceDigest: prepareTestSrc, TargetDigest: prepareTestTgt}
+	keyB := deltastore.GenerationKey{OrgID: orgId, ImageRepository: prepareTestRepo, SourceDigest: "sha256:ccc", TargetDigest: prepareTestTgt}
+
+	t.Run("When every joined generation is terminal it should complete and emit", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		require.NoError(t, store.InsertPrepareGenerations(ctx, prep.ID, []deltastore.GenerationKey{keyA, keyB}))
+		store.generations[keyA] = &model.DeltaGeneration{Status: model.DeltaGenerationSucceeded}
+		store.generations[keyB] = &model.DeltaGeneration{Status: model.DeltaGenerationFailed}
+		status := &statusSpy{}
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), status, &resumeSpy{}, nil)
+
+		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		assert.Equal(t, model.DeltaPrepareComplete, store.prepares[prep.ID].Status)
+		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+		require.Len(t, status.clears, 1)
+	})
+
+	t.Run("When a joined generation is still pending it should not complete", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		require.NoError(t, store.InsertPrepareGenerations(ctx, prep.ID, []deltastore.GenerationKey{keyA, keyB}))
+		store.generations[keyA] = &model.DeltaGeneration{Status: model.DeltaGenerationSucceeded}
+		store.generations[keyB] = &model.DeltaGeneration{Status: model.DeltaGenerationPending}
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
+
+		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		assert.Equal(t, model.DeltaPrepareWaiting, store.prepares[prep.ID].Status)
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+	})
+
+	t.Run("When no waiting prepare is joined it should not emit", func(t *testing.T) {
+		store := newFakePrepareStore()
+		store.generations[keyA] = &model.DeltaGeneration{Status: model.DeltaGenerationSucceeded}
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
+
+		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+	})
+
+	t.Run("When the prepare was superceded it should not emit", func(t *testing.T) {
+		store := newFakePrepareStore()
+		prep := store.seedWaiting(orgId, domain.FleetKind, "fleet-1", lo.ToPtr("tv-1"), nil, time.Now())
+		require.NoError(t, store.InsertPrepareGenerations(ctx, prep.ID, []deltastore.GenerationKey{keyA}))
+		store.generations[keyA] = &model.DeltaGeneration{Status: model.DeltaGenerationSucceeded}
+		require.NoError(t, store.CASPrepareStatus(ctx, prep.ID, model.DeltaPrepareFailed))
+		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
+
+		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
+	})
+}
+
 func TestPrepare_InsertAndAck(t *testing.T) {
 	orgId := uuid.New()
 	ctx := context.Background()
@@ -904,6 +960,38 @@ func (f *fakePrepareStore) GetGeneration(_ context.Context, key deltastore.Gener
 	}
 	cp := *gen
 	return &cp, nil
+}
+
+func (f *fakePrepareStore) ListWaitingPreparesByGeneration(_ context.Context, key deltastore.GenerationKey) ([]model.DeltaPrepare, error) {
+	var out []model.DeltaPrepare
+	for _, join := range f.joins {
+		if join.OrgID != key.OrgID || join.ImageRepository != key.ImageRepository || join.SourceDigest != key.SourceDigest || join.TargetDigest != key.TargetDigest {
+			continue
+		}
+		prep, ok := f.prepares[join.PrepareID]
+		if !ok || prep.Status != model.DeltaPrepareWaiting {
+			continue
+		}
+		cp := *prep
+		out = append(out, cp)
+	}
+	return out, nil
+}
+
+func (f *fakePrepareStore) ListPrepareGenerationKeys(_ context.Context, prepareID uuid.UUID) ([]deltastore.GenerationKey, error) {
+	var keys []deltastore.GenerationKey
+	for _, join := range f.joins {
+		if join.PrepareID != prepareID {
+			continue
+		}
+		keys = append(keys, deltastore.GenerationKey{
+			OrgID:           join.OrgID,
+			ImageRepository: join.ImageRepository,
+			SourceDigest:    join.SourceDigest,
+			TargetDigest:    join.TargetDigest,
+		})
+	}
+	return keys, nil
 }
 
 type statusSpy struct {

--- a/internal/delta_worker/prepare_test.go
+++ b/internal/delta_worker/prepare_test.go
@@ -237,7 +237,7 @@ func TestCompleteWaitingIfTerminal(t *testing.T) {
 		status := &statusSpy{}
 		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), status, &resumeSpy{}, nil)
 
-		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		require.NoError(t, p.CompleteWaitingIfTerminal(ctx, keyA))
 		assert.Equal(t, model.DeltaPrepareComplete, store.prepares[prep.ID].Status)
 		assert.Contains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 		require.Len(t, status.clears, 1)
@@ -251,7 +251,7 @@ func TestCompleteWaitingIfTerminal(t *testing.T) {
 		store.generations[keyB] = &model.DeltaGeneration{Status: model.DeltaGenerationPending}
 		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
 
-		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		require.NoError(t, p.CompleteWaitingIfTerminal(ctx, keyA))
 		assert.Equal(t, model.DeltaPrepareWaiting, store.prepares[prep.ID].Status)
 		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 	})
@@ -261,7 +261,7 @@ func TestCompleteWaitingIfTerminal(t *testing.T) {
 		store.generations[keyA] = &model.DeltaGeneration{Status: model.DeltaGenerationSucceeded}
 		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
 
-		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		require.NoError(t, p.CompleteWaitingIfTerminal(ctx, keyA))
 		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 	})
 
@@ -273,7 +273,7 @@ func TestCompleteWaitingIfTerminal(t *testing.T) {
 		require.NoError(t, store.CASPrepareStatus(ctx, prep.ID, model.DeltaPrepareFailed))
 		p := newTestPreparer(t, store, eligibleFleetResolver(fleetWithTV("fleet-1", "tv-1")), &statusSpy{}, &resumeSpy{}, nil)
 
-		require.NoError(t, p.completeWaitingIfTerminal(ctx, keyA))
+		require.NoError(t, p.CompleteWaitingIfTerminal(ctx, keyA))
 		assert.NotContains(t, resumeEventReasons(p), domain.EventReasonFleetRolloutStarted)
 	})
 }

--- a/internal/delta_worker/server.go
+++ b/internal/delta_worker/server.go
@@ -12,9 +12,13 @@ import (
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/instrumentation/metrics/worker"
 	"github.com/flightctl/flightctl/internal/oci"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	"github.com/flightctl/flightctl/internal/service/events"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
 	"github.com/flightctl/flightctl/internal/store"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
+	eventstore "github.com/flightctl/flightctl/internal/store/event"
 	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
 	repostore "github.com/flightctl/flightctl/internal/store/repository"
 	"github.com/flightctl/flightctl/internal/store/selector"
@@ -69,10 +73,15 @@ func (s *Server) newPreparer(ctx context.Context) (*Preparer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("delta publisher: %w", err)
 	}
+	taskPublisher, err := worker_client.QueuePublisher(ctx, s.queuesProvider)
+	if err != nil {
+		return nil, fmt.Errorf("task publisher: %w", err)
+	}
 	fleets := fleetstore.NewFleetStore(s.db, s.log)
 	devices := devicestore.NewDeviceStore(s.db, s.log)
 	tvs := tvstore.NewTemplateVersionStore(s.db, s.log)
 	repos := repostore.NewRepositoryStore(s.db, s.log)
+	eventsSvc := events.NewServiceHandler(eventstore.NewEventStore(s.db, s.log), worker_client.NewWorkerClient(taskPublisher, s.log, worker_client.WithDeltaPublisher(publisher)), s.log)
 	deployWait := s.cfg.DeltaGeneration.EffectiveMaxWaitForDelta()
 	deployTimeout := s.cfg.DeltaGeneration.EffectiveTimeout()
 	return &Preparer{
@@ -96,8 +105,10 @@ func (s *Server) newPreparer(ctx context.Context) (*Preparer, error) {
 			}
 			return d
 		},
-		Status: NewStorePreparingStatus(fleets, devices),
-		Resume: func(context.Context, worker_client.EventWithOrgId) error { return nil },
+		Status:    NewStorePreparingStatus(fleets, devices),
+		Events:    eventsSvc,
+		FleetSvc:  fleetservice.NewServiceHandler(fleets, nil, eventsSvc, s.log),
+		DeviceSvc: deviceservice.NewDeviceServiceHandler(devices, nil, fleets, eventsSvc, nil, "", s.log),
 	}, nil
 }
 

--- a/internal/delta_worker/server.go
+++ b/internal/delta_worker/server.go
@@ -15,6 +15,7 @@ import (
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	"github.com/flightctl/flightctl/internal/service/events"
 	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	"github.com/flightctl/flightctl/internal/store"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
@@ -109,6 +110,7 @@ func (s *Server) newPreparer(ctx context.Context) (*Preparer, error) {
 		Events:    eventsSvc,
 		FleetSvc:  fleetservice.NewServiceHandler(fleets, nil, eventsSvc, s.log),
 		DeviceSvc: deviceservice.NewDeviceServiceHandler(devices, nil, fleets, eventsSvc, nil, "", s.log),
+		TVSvc:     templateversionservice.NewServiceHandler(tvs, nil, eventsSvc, s.log),
 	}, nil
 }
 

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -27,6 +27,7 @@ import (
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
 	resourcesyncservice "github.com/flightctl/flightctl/internal/service/resourcesync"
 	syncstateservice "github.com/flightctl/flightctl/internal/service/syncstate"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	catalogstore "github.com/flightctl/flightctl/internal/store/catalog"
 	checkpointstore "github.com/flightctl/flightctl/internal/store/checkpoint"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
@@ -38,6 +39,7 @@ import (
 	repositorystore "github.com/flightctl/flightctl/internal/store/repository"
 	resourcesyncstore "github.com/flightctl/flightctl/internal/store/resourcesync"
 	syncstatestore "github.com/flightctl/flightctl/internal/store/syncstate"
+	templateversionstore "github.com/flightctl/flightctl/internal/store/templateversion"
 	vulnerabilityfindingstore "github.com/flightctl/flightctl/internal/store/vulnerabilityfinding"
 	"github.com/flightctl/flightctl/internal/tasks"
 	trustifyv2 "github.com/flightctl/flightctl/internal/trustify/v2"
@@ -118,6 +120,7 @@ func (s *Server) Run(ctx context.Context) error {
 	organizationStore := organizationstore.NewOrganizationStore(s.db)
 	dependencyRefStore := dependencyrefstore.NewDependencyRefStore(s.db, s.log.WithField("pkg", "dependencyref-store"))
 	syncStateStore := syncstatestore.NewSyncStateStore(s.db, s.log.WithField("pkg", "syncstate-store"))
+	tvStore := templateversionstore.NewTemplateVersionStore(s.db, s.log.WithField("pkg", "templateversion-store"))
 	vulnerabilityFindingStore := vulnerabilityfindingstore.NewVulnerabilityFindingStore(s.db, s.log.WithField("pkg", "vulnerabilityfinding-store"))
 
 	eventsSvc := events.NewServiceHandler(eventStore, workerClient, s.log)
@@ -132,6 +135,7 @@ func (s *Server) Run(ctx context.Context) error {
 	organizationSvc := organizationservice.WrapWithTracing(organizationservice.NewServiceHandler(organizationStore))
 	dependencyrefSvc := dependencyrefservice.WrapWithTracing(dependencyrefservice.NewServiceHandler(dependencyRefStore, s.log))
 	syncstateSvc := syncstateservice.WrapWithTracing(syncstateservice.NewServiceHandler(syncStateStore))
+	tvSvc := templateversionservice.WrapWithTracing(templateversionservice.NewServiceHandler(tvStore, kvStore, eventsSvc, s.log))
 
 	var secretInformerClientset kubernetes.Interface
 	if s.cfg.Periodic != nil && s.cfg.Periodic.ClusterLevelSecretAccess {
@@ -170,7 +174,7 @@ func (s *Server) Run(ctx context.Context) error {
 	periodicTaskExecutors := InitializeTaskExecutors(s.log,
 		repositorySvc, fleetSvc, resourceSyncSvc, catalogSvc, deviceSvc, eventSvc,
 		checkpointSvc, organizationSvc, dependencyrefSvc, syncstateSvc,
-		s.cfg, queuesProvider, workerClient, nil, vulnerabilityFindingStore, vulnClient, depSyncMetrics, deltastore.NewStore(s.db, s.log))
+		s.cfg, queuesProvider, workerClient, nil, vulnerabilityFindingStore, vulnClient, depSyncMetrics, deltastore.NewStore(s.db, s.log), tvSvc)
 
 	// Create channel manager for task distribution
 	channelManagerConfig := ChannelManagerConfig{

--- a/internal/periodic_checker/server.go
+++ b/internal/periodic_checker/server.go
@@ -29,6 +29,7 @@ import (
 	syncstateservice "github.com/flightctl/flightctl/internal/service/syncstate"
 	catalogstore "github.com/flightctl/flightctl/internal/store/catalog"
 	checkpointstore "github.com/flightctl/flightctl/internal/store/checkpoint"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	dependencyrefstore "github.com/flightctl/flightctl/internal/store/dependencyref"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
 	eventstore "github.com/flightctl/flightctl/internal/store/event"
@@ -169,7 +170,7 @@ func (s *Server) Run(ctx context.Context) error {
 	periodicTaskExecutors := InitializeTaskExecutors(s.log,
 		repositorySvc, fleetSvc, resourceSyncSvc, catalogSvc, deviceSvc, eventSvc,
 		checkpointSvc, organizationSvc, dependencyrefSvc, syncstateSvc,
-		s.cfg, queuesProvider, workerClient, nil, vulnerabilityFindingStore, vulnClient, depSyncMetrics)
+		s.cfg, queuesProvider, workerClient, nil, vulnerabilityFindingStore, vulnClient, depSyncMetrics, deltastore.NewStore(s.db, s.log))
 
 	// Create channel manager for task distribution
 	channelManagerConfig := ChannelManagerConfig{

--- a/internal/periodic_checker/task_definitions.go
+++ b/internal/periodic_checker/task_definitions.go
@@ -23,6 +23,7 @@ import (
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
 	resourcesyncservice "github.com/flightctl/flightctl/internal/service/resourcesync"
 	syncstateservice "github.com/flightctl/flightctl/internal/service/syncstate"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	vulnerabilityfindingstore "github.com/flightctl/flightctl/internal/store/vulnerabilityfinding"
 	"github.com/flightctl/flightctl/internal/tasks"
@@ -227,12 +228,13 @@ type DeltaPrepareDeadlineExecutor struct {
 	deltaStore deltastore.Store
 	fleetSvc   fleetservice.Service
 	deviceSvc  deviceservice.Service
+	tvSvc      templateversionservice.Service
 	eventSvc   eventservice.Service
 }
 
 func (e *DeltaPrepareDeadlineExecutor) Execute(ctx context.Context, log logrus.FieldLogger, orgId uuid.UUID) {
 	taskCtx := createTaskContext(ctx, PeriodicTaskTypeDeltaPrepareDeadline)
-	tasks.NewDeltaPrepareDeadline(e.log, e.deltaStore, e.fleetSvc, e.deviceSvc, e.eventSvc).Poll(taskCtx)
+	tasks.NewDeltaPrepareDeadline(e.log, e.deltaStore, e.fleetSvc, e.deviceSvc, e.tvSvc, e.eventSvc).Poll(taskCtx)
 }
 
 type QueueMaintenanceExecutor struct {
@@ -353,6 +355,7 @@ func InitializeTaskExecutors(
 	vulnClient trustifyv2.VulnerabilityClient,
 	depSyncMetrics *periodicmetrics.DependencySyncCollector,
 	deltaStore deltastore.Store,
+	tvSvc templateversionservice.Service,
 ) map[PeriodicTaskType]PeriodicTaskExecutor {
 	executors := map[PeriodicTaskType]PeriodicTaskExecutor{
 		PeriodicTaskTypeRepositoryTester: &RepositoryTesterExecutor{
@@ -393,6 +396,7 @@ func InitializeTaskExecutors(
 			deltaStore: deltaStore,
 			fleetSvc:   fleetSvc,
 			deviceSvc:  deviceSvc,
+			tvSvc:      tvSvc,
 			eventSvc:   eventSvc,
 		},
 		PeriodicTaskTypeQueueMaintenance: &QueueMaintenanceExecutor{

--- a/internal/periodic_checker/task_definitions.go
+++ b/internal/periodic_checker/task_definitions.go
@@ -23,6 +23,7 @@ import (
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
 	resourcesyncservice "github.com/flightctl/flightctl/internal/service/resourcesync"
 	syncstateservice "github.com/flightctl/flightctl/internal/service/syncstate"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	vulnerabilityfindingstore "github.com/flightctl/flightctl/internal/store/vulnerabilityfinding"
 	"github.com/flightctl/flightctl/internal/tasks"
 	trustifyv2 "github.com/flightctl/flightctl/internal/trustify/v2"
@@ -52,6 +53,7 @@ const (
 	PeriodicTaskTypeVulnerabilitySync      PeriodicTaskType = "vulnerability-sync"
 	PeriodicTaskTypeDependencySyncGit      PeriodicTaskType = "dependency-sync-git"
 	PeriodicTaskTypeDependencySyncHttp     PeriodicTaskType = "dependency-sync-http"
+	PeriodicTaskTypeDeltaPrepareDeadline   PeriodicTaskType = "delta-prepare-deadline"
 )
 
 type PeriodicTaskMetadata struct {
@@ -70,6 +72,7 @@ var periodicTasks = map[PeriodicTaskType]PeriodicTaskMetadata{
 	PeriodicTaskTypeVulnerabilitySync:      {Interval: tasks.VulnerabilitySyncInterval, SystemWide: true},
 	PeriodicTaskTypeDependencySyncGit:      {Interval: config.DefaultDependencySyncTaskInterval, SystemWide: false},
 	PeriodicTaskTypeDependencySyncHttp:     {Interval: config.DefaultDependencySyncTaskInterval, SystemWide: false},
+	PeriodicTaskTypeDeltaPrepareDeadline:   {Interval: tasks.DeltaPrepareDeadlinePollingInterval, SystemWide: true},
 }
 
 // MergeTasksWithConfig merges configured task intervals with defaults.
@@ -219,6 +222,19 @@ func (e *EventCleanupExecutor) Execute(ctx context.Context, log logrus.FieldLogg
 	eventCleanup.Poll(taskCtx)
 }
 
+type DeltaPrepareDeadlineExecutor struct {
+	log        logrus.FieldLogger
+	deltaStore deltastore.Store
+	fleetSvc   fleetservice.Service
+	deviceSvc  deviceservice.Service
+	eventSvc   eventservice.Service
+}
+
+func (e *DeltaPrepareDeadlineExecutor) Execute(ctx context.Context, log logrus.FieldLogger, orgId uuid.UUID) {
+	taskCtx := createTaskContext(ctx, PeriodicTaskTypeDeltaPrepareDeadline)
+	tasks.NewDeltaPrepareDeadline(e.log, e.deltaStore, e.fleetSvc, e.deviceSvc, e.eventSvc).Poll(taskCtx)
+}
+
 type QueueMaintenanceExecutor struct {
 	log             logrus.FieldLogger
 	checkpointSvc   checkpointservice.Service
@@ -336,6 +352,7 @@ func InitializeTaskExecutors(
 	findingStore vulnerabilityfindingstore.Store,
 	vulnClient trustifyv2.VulnerabilityClient,
 	depSyncMetrics *periodicmetrics.DependencySyncCollector,
+	deltaStore deltastore.Store,
 ) map[PeriodicTaskType]PeriodicTaskExecutor {
 	executors := map[PeriodicTaskType]PeriodicTaskExecutor{
 		PeriodicTaskTypeRepositoryTester: &RepositoryTesterExecutor{
@@ -370,6 +387,13 @@ func InitializeTaskExecutors(
 			log:                  log.WithField("pkg", "event-cleanup"),
 			eventSvc:             eventSvc,
 			eventRetentionPeriod: cfg.Service.EventRetentionPeriod,
+		},
+		PeriodicTaskTypeDeltaPrepareDeadline: &DeltaPrepareDeadlineExecutor{
+			log:        log.WithField("pkg", "delta-prepare-deadline"),
+			deltaStore: deltaStore,
+			fleetSvc:   fleetSvc,
+			deviceSvc:  deviceSvc,
+			eventSvc:   eventSvc,
 		},
 		PeriodicTaskTypeQueueMaintenance: &QueueMaintenanceExecutor{
 			log:             log.WithField("pkg", "queue-maintenance"),

--- a/internal/periodic_checker/task_definitions_test.go
+++ b/internal/periodic_checker/task_definitions_test.go
@@ -205,3 +205,11 @@ func TestMergeTasksWithConfig_VulnerabilitySync(t *testing.T) {
 		})
 	}
 }
+
+func TestDeltaPrepareDeadlineTaskMetadata(t *testing.T) {
+	meta, ok := periodicTasks[PeriodicTaskTypeDeltaPrepareDeadline]
+	require.True(t, ok)
+	require.True(t, meta.SystemWide)
+	require.Equal(t, time.Minute, meta.Interval)
+	require.Contains(t, MergeTasksWithConfig(nil), PeriodicTaskTypeDeltaPrepareDeadline)
+}

--- a/internal/service/device/events.go
+++ b/internal/service/device/events.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/service/common"
 	"github.com/flightctl/flightctl/internal/service/events"
+	"github.com/flightctl/flightctl/internal/util"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 )
@@ -68,10 +69,33 @@ func EmitDeviceUpdatedEvent(ctx context.Context, eventsService events.Service, l
 
 	annotations := map[string]string{}
 	delayDeviceRender, ok := ctx.Value(consts.DelayDeviceRenderCtxKey).(bool)
-	if ok && delayDeviceRender {
+	holdStandalone := deviceSpecsChanged(oldDevice, newDevice) && !hasFleetOwner(newDevice)
+	if (ok && delayDeviceRender) || holdStandalone {
 		annotations[domain.EventAnnotationDelayDeviceRender] = "true"
 	}
 	eventsService.CreateEvent(ctx, orgId, common.GetResourceCreatedOrUpdatedSuccessEvent(ctx, false, domain.DeviceKind, name, updateDetails, log, annotations))
+	if holdStandalone {
+		emitStandalonePrepareDeltas(ctx, eventsService, orgId, name)
+	}
+}
+
+func hasFleetOwner(device *domain.Device) bool {
+	if device == nil {
+		return false
+	}
+	kind, _, err := util.GetResourceOwner(device.Metadata.Owner)
+	return err == nil && kind == domain.FleetKind
+}
+
+func emitStandalonePrepareDeltas(ctx context.Context, eventsService events.Service, orgId uuid.UUID, name string) {
+	details := domain.PrepareDeltasDetails{
+		DetailType: domain.PrepareDeltasDetailsDetailType("PrepareDeltas"),
+	}
+	var eventDetails domain.EventDetails
+	if err := eventDetails.FromPrepareDeltasDetails(details); err != nil {
+		return
+	}
+	eventsService.CreateEvent(ctx, orgId, domain.GetBaseEvent(ctx, domain.DeviceKind, name, domain.EventReasonPrepareDeltas, "Preparing OS image deltas", &eventDetails))
 }
 
 func ensureSpecUpdatedField(details *domain.ResourceUpdatedDetails, oldDevice, newDevice *domain.Device) *domain.ResourceUpdatedDetails {

--- a/internal/service/device/events_test.go
+++ b/internal/service/device/events_test.go
@@ -47,7 +47,7 @@ func TestEmitDeviceUpdatedEvent(t *testing.T) {
 		require.NotPanics(t, func() {
 			EmitDeviceUpdatedEvent(context.Background(), ev, logrus.New(), domain.DeviceKind, uuid.New(), "dev1", oldDevice, device, false, nil)
 		})
-		require.Len(t, ev.created, 1)
+		require.NotEmpty(t, ev.created)
 	})
 
 	t.Run("When multiple status fields transition to Unknown it should deduplicate DeviceDisconnected events", func(t *testing.T) {
@@ -71,6 +71,46 @@ func TestEmitDeviceUpdatedEvent(t *testing.T) {
 			}
 		}
 		require.Equal(t, 1, count)
+	})
+
+	t.Run("When a standalone spec update it should delay render and emit PrepareDeltas", func(t *testing.T) {
+		ev := &fakeEvents{}
+		oldDevice := prepareTestDeviceForEvents("dev1")
+		newDevice := prepareTestDeviceForEvents("dev1")
+		newDevice.Spec = &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-2"}}
+		EmitDeviceUpdatedEvent(context.Background(), ev, logrus.New(), domain.DeviceKind, uuid.New(), "dev1", oldDevice, newDevice, false, nil)
+		var reasons []domain.EventReason
+		var delayed bool
+		for _, e := range ev.created {
+			reasons = append(reasons, e.Reason)
+			if e.Reason == domain.EventReasonResourceUpdated && e.Metadata.Annotations != nil {
+				delayed = (*e.Metadata.Annotations)[domain.EventAnnotationDelayDeviceRender] == "true"
+			}
+			if e.Reason == domain.EventReasonPrepareDeltas {
+				details, err := e.Details.AsPrepareDeltasDetails()
+				require.NoError(t, err)
+				require.Nil(t, details.TemplateVersion)
+			}
+		}
+		require.Contains(t, reasons, domain.EventReasonResourceUpdated)
+		require.Contains(t, reasons, domain.EventReasonPrepareDeltas)
+		require.True(t, delayed)
+	})
+
+	t.Run("When a fleet-owned spec update it should not emit PrepareDeltas or delay render", func(t *testing.T) {
+		ev := &fakeEvents{}
+		oldDevice := prepareTestDeviceForEvents("dev1")
+		oldDevice.Metadata.Owner = lo.ToPtr("Fleet/f1")
+		newDevice := prepareTestDeviceForEvents("dev1")
+		newDevice.Metadata.Owner = lo.ToPtr("Fleet/f1")
+		newDevice.Spec = &domain.DeviceSpec{Os: &domain.DeviceOsSpec{Image: "img-2"}}
+		EmitDeviceUpdatedEvent(context.Background(), ev, logrus.New(), domain.DeviceKind, uuid.New(), "dev1", oldDevice, newDevice, false, nil)
+		for _, e := range ev.created {
+			require.NotEqual(t, domain.EventReasonPrepareDeltas, e.Reason)
+			if e.Reason == domain.EventReasonResourceUpdated && e.Metadata.Annotations != nil {
+				require.NotEqual(t, "true", (*e.Metadata.Annotations)[domain.EventAnnotationDelayDeviceRender])
+			}
+		}
 	})
 
 	t.Run("When the resources cannot be cast to *domain.Device it should no-op", func(t *testing.T) {

--- a/internal/service/templateversion/handler.go
+++ b/internal/service/templateversion/handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/flightctl/flightctl/internal/kvstore"
 	"github.com/flightctl/flightctl/internal/service/common"
 	"github.com/flightctl/flightctl/internal/service/events"
-	"github.com/flightctl/flightctl/internal/service/fleet"
 	"github.com/flightctl/flightctl/internal/store"
 	"github.com/flightctl/flightctl/internal/store/selector"
 	templateversionstore "github.com/flightctl/flightctl/internal/store/templateversion"
@@ -38,9 +37,6 @@ func (h *ServiceHandler) CreateTemplateVersion(ctx context.Context, orgId uuid.U
 	}
 
 	result, err := h.store.Create(ctx, orgId, &templateVersion, h.callbackTemplateVersionUpdated)
-	if err == nil {
-		fleet.EmitFleetRolloutStartedEvent(ctx, h.events, orgId, lo.FromPtr(templateVersion.Metadata.Name), templateVersion.Spec.Fleet, immediateRollout)
-	}
 	return result, common.StoreErrorToApiStatus(err, true, domain.TemplateVersionKind, templateVersion.Metadata.Name)
 }
 

--- a/internal/service/templateversion/handler_test.go
+++ b/internal/service/templateversion/handler_test.go
@@ -165,7 +165,7 @@ func testTemplateVersion(fleet, name string) domain.TemplateVersion {
 }
 
 func TestCreateTemplateVersion(t *testing.T) {
-	t.Run("When the resource is valid it should create it and emit a fleet rollout started event", func(t *testing.T) {
+	t.Run("When the resource is valid it should create it without emitting fleet rollout started", func(t *testing.T) {
 		h, fakeStore, _, fakeEvents := newTestHandler()
 		tv := testTemplateVersion("myfleet", "v1")
 
@@ -173,13 +173,11 @@ func TestCreateTemplateVersion(t *testing.T) {
 		require.Equal(t, statusCreatedCode, status.Code)
 		require.NotNil(t, result)
 		require.Contains(t, fakeStore.items, tvKey{fleet: "myfleet", name: "v1"})
-		// CreateTemplateVersion emits both the fleet-rollout-started event and the
-		// template version's own ResourceCreated event.
 		var reasons []domain.EventReason
 		for _, e := range fakeEvents.created {
 			reasons = append(reasons, e.Reason)
 		}
-		require.Contains(t, reasons, domain.EventReasonFleetRolloutStarted)
+		require.NotContains(t, reasons, domain.EventReasonFleetRolloutStarted)
 		require.Contains(t, reasons, domain.EventReasonResourceCreated)
 	})
 

--- a/internal/store/delta/store.go
+++ b/internal/store/delta/store.go
@@ -34,6 +34,7 @@ type Store interface {
 	CASPrepareStatus(ctx context.Context, id uuid.UUID, to string) error
 	ListWaitingPastDeadline(ctx context.Context) ([]model.DeltaPrepare, error)
 	ListWaitingPreparesByGeneration(ctx context.Context, key GenerationKey) ([]model.DeltaPrepare, error)
+	ListPrepareGenerationKeys(ctx context.Context, prepareID uuid.UUID) ([]GenerationKey, error)
 	InsertPrepareGenerations(ctx context.Context, prepareID uuid.UUID, keys []GenerationKey) error
 	GetWaitingPrepare(ctx context.Context, orgID uuid.UUID, kind, name string) (*model.DeltaPrepare, error)
 }
@@ -382,6 +383,24 @@ func (s *DeltaStore) ListWaitingPreparesByGeneration(ctx context.Context, key Ge
 		return nil, store.ErrorFromGormError(result.Error)
 	}
 	return rows, nil
+}
+
+func (s *DeltaStore) ListPrepareGenerationKeys(ctx context.Context, prepareID uuid.UUID) ([]GenerationKey, error) {
+	var rows []model.DeltaPrepareGeneration
+	result := s.getDB(ctx).Where("prepare_id = ?", prepareID).Find(&rows)
+	if result.Error != nil {
+		return nil, store.ErrorFromGormError(result.Error)
+	}
+	keys := make([]GenerationKey, 0, len(rows))
+	for _, row := range rows {
+		keys = append(keys, GenerationKey{
+			OrgID:           row.OrgID,
+			ImageRepository: row.ImageRepository,
+			SourceDigest:    row.SourceDigest,
+			TargetDigest:    row.TargetDigest,
+		})
+	}
+	return keys, nil
 }
 
 func (s *DeltaStore) CASPrepareStatus(ctx context.Context, id uuid.UUID, to string) error {

--- a/internal/tasks/consumer.go
+++ b/internal/tasks/consumer.go
@@ -304,7 +304,8 @@ func shouldRenderDevice(ctx context.Context, event domain.Event, log logrus.Fiel
 		domain.EventReasonDependencyChangeDetected,
 		domain.EventReasonResourceCreated,
 		domain.EventReasonFleetRolloutDeviceSelected, domain.EventReasonDeviceConflictResolved,
-		domain.EventReasonDeviceDecommissioned, domain.EventReasonApplicationLifecycleChanged}, event.Reason) {
+		domain.EventReasonDeviceDecommissioned, domain.EventReasonApplicationLifecycleChanged,
+		domain.EventReasonDeltaGenerationCompleted}, event.Reason) {
 		return true
 	}
 

--- a/internal/tasks/consumer.go
+++ b/internal/tasks/consumer.go
@@ -30,14 +30,31 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func dispatchTasks(fleetSvc fleetservice.Service, templateversionSvc templateversionservice.Service, deviceSvc deviceservice.Service, dependencyrefSvc dependencyrefservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, eventSvc eventservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, workerMetrics *worker.WorkerCollector, encryptionMigrator *EncryptionMigrator, queuePublisher queues.QueueProducer) queues.ConsumeHandler {
+type TaskConsumer struct {
+	FleetSvc           fleetservice.Service
+	TemplateversionSvc templateversionservice.Service
+	DeviceSvc          deviceservice.Service
+	DependencyrefSvc   dependencyrefservice.Service
+	RepositorySvc      repositoryservice.Service
+	CatalogSvc         catalogservice.Service
+	EventSvc           eventservice.Service
+	K8sClient          k8sclient.K8SClient
+	KVStore            kvstore.KVStore
+	Cfg                *config.Config
+	WorkerMetrics      *worker.WorkerCollector
+	EncryptionMigrator *EncryptionMigrator
+	QueuePublisher     queues.QueueProducer
+	WorkerClient       worker_client.WorkerClient
+}
+
+func (d TaskConsumer) dispatch() queues.ConsumeHandler {
 	return func(ctx context.Context, payload []byte, entryID string, consumer queues.QueueConsumer, log logrus.FieldLogger) error {
 		startTime := time.Now()
 
 		// Increment in-progress counter
-		if workerMetrics != nil {
-			workerMetrics.IncMessagesInProgress()
-			defer workerMetrics.DecMessagesInProgress()
+		if d.WorkerMetrics != nil {
+			d.WorkerMetrics.IncMessagesInProgress()
+			defer d.WorkerMetrics.DecMessagesInProgress()
 		}
 
 		// Add timeout for the entire event processing
@@ -48,9 +65,9 @@ func dispatchTasks(fleetSvc fleetservice.Service, templateversionSvc templatever
 		if err := json.Unmarshal(payload, &eventWithOrgId); err != nil {
 			log.WithError(err).Error("failed to unmarshal consume payload")
 			// Record unmarshal error as a permanent failure (parsing errors are not retryable)
-			if workerMetrics != nil {
-				workerMetrics.IncPermanentFailures()
-				workerMetrics.IncMessagesProcessed("permanent_failure")
+			if d.WorkerMetrics != nil {
+				d.WorkerMetrics.IncPermanentFailures()
+				d.WorkerMetrics.IncMessagesProcessed("permanent_failure")
 			}
 			// Complete the message successfully to remove it from queue (parsing errors are not retryable)
 			ackCtx, cancelAck := context.WithTimeout(context.Background(), AckTimeout)
@@ -78,57 +95,66 @@ func dispatchTasks(fleetSvc fleetservice.Service, templateversionSvc templatever
 
 		if shouldRolloutFleet(ctx, eventWithOrgId.Event, log) {
 			taskName = "fleetRollout"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return fleetRollout(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, fleetSvc, templateversionSvc, deviceSvc, dependencyrefSvc, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				return fleetRollout(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.FleetSvc, d.TemplateversionSvc, d.DeviceSvc, d.DependencyrefSvc, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
 		if shouldReconcileDeviceOwnership(ctx, eventWithOrgId.Event, log) {
 			taskName = "fleetSelectorMatching"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return fleetSelectorMatching(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, deviceSvc, fleetSvc, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				return fleetSelectorMatching(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.DeviceSvc, d.FleetSvc, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
 		if shouldValidateFleet(ctx, eventWithOrgId.Event, log) {
 			taskName = "fleetValidation"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return fleetValidate(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, fleetSvc, templateversionSvc, deviceSvc, repositorySvc, k8sClient, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				if eventWithOrgId.Event.InvolvedObject.Kind != domain.FleetKind {
+					log.Errorf("FleetValidate called with unexpected kind %s and reason %s", eventWithOrgId.Event.InvolvedObject.Kind, eventWithOrgId.Event.Reason)
+					return nil
+				}
+				logic := NewFleetValidateLogic(log, d.FleetSvc, d.TemplateversionSvc, d.DeviceSvc, d.RepositorySvc, d.K8sClient, eventWithOrgId.OrgId, eventWithOrgId.Event)
+				logic.workerClient = d.WorkerClient
+				if err := logic.CreateNewTemplateVersionIfFleetValid(ctx); err != nil {
+					log.Errorf("failed validating fleet %s/%s: %v", eventWithOrgId.OrgId, eventWithOrgId.Event.InvolvedObject.Name, err)
+				}
+				return nil
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
 		if shouldPopulateDependencyRefs(ctx, eventWithOrgId.Event, log) {
 			taskName = "populateDependencyRefs"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return populateDependencyRefs(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, fleetSvc, deviceSvc, dependencyrefSvc, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				return populateDependencyRefs(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.FleetSvc, d.DeviceSvc, d.DependencyrefSvc, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
 		if shouldRenderDevice(ctx, eventWithOrgId.Event, log) {
 			taskName = "deviceRender"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return deviceRender(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, deviceSvc, repositorySvc, catalogSvc, k8sClient, kvStore, cfg, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				return deviceRender(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.DeviceSvc, d.RepositorySvc, d.CatalogSvc, d.K8sClient, d.KVStore, d.Cfg, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
 		if shouldUpdateRepositoryReferers(ctx, eventWithOrgId.Event, log) {
 			taskName = "repositoryUpdate"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return repositoryUpdate(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, repositorySvc, eventSvc, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				return repositoryUpdate(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.RepositorySvc, d.EventSvc, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
 		if shouldReconcileFleetApplicationLifecycle(ctx, eventWithOrgId.Event, log) {
 			taskName = "fleetApplicationLifecycle"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return fleetApplicationLifecycle(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, fleetSvc, deviceSvc, eventSvc, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				return fleetApplicationLifecycle(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.FleetSvc, d.DeviceSvc, d.EventSvc, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
 		if shouldRunEncryptionMigration(eventWithOrgId.Event) {
 			taskName = "encryptionMigration"
-			err = runTaskWithMetrics(taskName, workerMetrics, func() error {
-				return runEncryptionMigrationBatch(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, encryptionMigrator, queuePublisher, log)
+			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
+				return runEncryptionMigrationBatch(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.EncryptionMigrator, d.QueuePublisher, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}
@@ -142,7 +168,7 @@ func dispatchTasks(fleetSvc fleetservice.Service, templateversionSvc templatever
 			// ensure emission even if processing ctx timed out
 			emitCtx, cancelEmit := context.WithTimeout(context.Background(), AckTimeout)
 			defer cancelEmit()
-			EmitInternalTaskFailedEvent(emitCtx, eventWithOrgId.OrgId, errorMessage, eventWithOrgId.Event, eventSvc)
+			EmitInternalTaskFailedEvent(emitCtx, eventWithOrgId.OrgId, errorMessage, eventWithOrgId.Event, d.EventSvc)
 			returnErr = errors.New(errorMessage)
 		}
 
@@ -155,17 +181,14 @@ func dispatchTasks(fleetSvc fleetservice.Service, templateversionSvc templatever
 		}
 
 		// Record metrics only after successful completion
-		if workerMetrics != nil {
-			// Record processing duration
-			workerMetrics.ObserveProcessingDuration(time.Since(startTime))
+		if d.WorkerMetrics != nil {
+			d.WorkerMetrics.ObserveProcessingDuration(time.Since(startTime))
 
 			if len(errorMessages) > 0 {
-				// Record message queued for retry (actual retry/permanent failure determination happens in queue maintenance)
-				workerMetrics.IncMessagesProcessed("queued_for_retry")
+				d.WorkerMetrics.IncMessagesProcessed("queued_for_retry")
 			} else {
-				// Record successful processing
-				workerMetrics.IncMessagesProcessed("success")
-				workerMetrics.UpdateLastSuccessfulTask()
+				d.WorkerMetrics.IncMessagesProcessed("success")
+				d.WorkerMetrics.UpdateLastSuccessfulTask()
 			}
 		}
 
@@ -405,30 +428,14 @@ func hasUpdatedFields(details *domain.EventDetails, log logrus.FieldLogger, fiel
 	return false
 }
 
-func LaunchConsumers(ctx context.Context,
-	queuesProvider queues.Provider,
-	fleetSvc fleetservice.Service,
-	templateversionSvc templateversionservice.Service,
-	deviceSvc deviceservice.Service,
-	dependencyrefSvc dependencyrefservice.Service,
-	repositorySvc repositoryservice.Service,
-	catalogSvc catalogservice.Service,
-	eventSvc eventservice.Service,
-	k8sClient k8sclient.K8SClient,
-	kvStore kvstore.KVStore,
-	cfg *config.Config,
-	numConsumers, threadsPerConsumer int,
-	workerMetrics *worker.WorkerCollector,
-	encryptionMigrator *EncryptionMigrator,
-	queuePublisher queues.QueueProducer) error {
+func LaunchConsumers(ctx context.Context, queuesProvider queues.Provider, d TaskConsumer, numConsumers, threadsPerConsumer int) error {
 	totalConsumers := numConsumers * threadsPerConsumer
 
-	// Set active consumers metric
-	if workerMetrics != nil {
-		workerMetrics.SetConsumersActive(float64(totalConsumers))
+	if d.WorkerMetrics != nil {
+		d.WorkerMetrics.SetConsumersActive(float64(totalConsumers))
 		go func() {
 			<-ctx.Done()
-			workerMetrics.SetConsumersActive(0)
+			d.WorkerMetrics.SetConsumersActive(0)
 		}()
 	}
 
@@ -438,7 +445,7 @@ func LaunchConsumers(ctx context.Context,
 			return err
 		}
 		for j := 0; j != threadsPerConsumer; j++ {
-			if err = consumer.Consume(ctx, dispatchTasks(fleetSvc, templateversionSvc, deviceSvc, dependencyrefSvc, repositorySvc, catalogSvc, eventSvc, k8sClient, kvStore, cfg, workerMetrics, encryptionMigrator, queuePublisher)); err != nil {
+			if err = consumer.Consume(ctx, d.dispatch()); err != nil {
 				return err
 			}
 		}

--- a/internal/tasks/consumer.go
+++ b/internal/tasks/consumer.go
@@ -115,7 +115,7 @@ func (d TaskConsumer) dispatch() queues.ConsumeHandler {
 					return nil
 				}
 				logic := NewFleetValidateLogic(log, d.FleetSvc, d.TemplateversionSvc, d.DeviceSvc, d.RepositorySvc, d.K8sClient, eventWithOrgId.OrgId, eventWithOrgId.Event)
-				logic.workerClient = d.WorkerClient
+				logic.WorkerClient = d.WorkerClient
 				if err := logic.CreateNewTemplateVersionIfFleetValid(ctx); err != nil {
 					log.Errorf("failed validating fleet %s/%s: %v", eventWithOrgId.OrgId, eventWithOrgId.Event.InvolvedObject.Name, err)
 				}

--- a/internal/tasks/consumer_test.go
+++ b/internal/tasks/consumer_test.go
@@ -346,7 +346,7 @@ func TestShouldRenderDevice(t *testing.T) {
 		{
 			name:     "DeltaGenerationCompleted",
 			event:    createTestEvent(domain.DeviceKind, domain.EventReasonDeltaGenerationCompleted, "device1"),
-			expected: false,
+			expected: true,
 		},
 	}
 

--- a/internal/tasks/consumer_test.go
+++ b/internal/tasks/consumer_test.go
@@ -514,7 +514,7 @@ func TestDispatchTasks_WithNilMetrics(t *testing.T) {
 	mockConsumer.On("Complete", mock.Anything, "entry-123", payload, mock.MatchedBy(func(e error) bool { return e == nil })).Return(nil)
 
 	// Create dispatcher with nil metrics
-	handler := dispatchTasks(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	handler := TaskConsumer{}.dispatch()
 
 	// Execute handler
 	err = handler(ctx, payload, "entry-123", mockConsumer, log)
@@ -549,7 +549,7 @@ func TestDispatchTasks_WithNilMetrics_SuccessfulProcessing(t *testing.T) {
 	mockConsumer.On("Complete", mock.Anything, "entry-123", payload, mock.MatchedBy(func(e error) bool { return e == nil })).Return(nil)
 
 	// Create dispatcher with nil metrics
-	handler := dispatchTasks(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	handler := TaskConsumer{}.dispatch()
 
 	// Execute handler
 	err = handler(ctx, payload, "entry-123", mockConsumer, log)
@@ -572,7 +572,7 @@ func TestDispatchTasks_WithNilMetrics_InvalidPayload(t *testing.T) {
 	mockConsumer.On("Complete", mock.Anything, "entry-123", payload, nil).Return(nil)
 
 	// Create dispatcher with nil metrics
-	handler := dispatchTasks(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	handler := TaskConsumer{}.dispatch()
 
 	// Execute handler
 	err := handler(ctx, payload, "entry-123", mockConsumer, log)

--- a/internal/tasks/delta_prepare_deadline.go
+++ b/internal/tasks/delta_prepare_deadline.go
@@ -100,6 +100,9 @@ func (t *DeltaPrepareDeadline) identityMatches(ctx context.Context, prep *model.
 	case domain.DeviceKind:
 		device, status := t.deviceSvc.GetDevice(ctx, prep.OrgID, prep.Name)
 		if status.Code != http.StatusOK {
+			if status.Code == http.StatusNotFound {
+				return false, nil
+			}
 			return false, fmt.Errorf("getting device %s: %s", prep.Name, status.Message)
 		}
 		return equalInt64Ptr(prep.SpecResourceVersion, device.Metadata.Generation), nil

--- a/internal/tasks/delta_prepare_deadline.go
+++ b/internal/tasks/delta_prepare_deadline.go
@@ -1,0 +1,198 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/service/common"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	eventservice "github.com/flightctl/flightctl/internal/service/event"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/flightctl/flightctl/internal/util"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+)
+
+const DeltaPrepareDeadlinePollingInterval = time.Minute
+
+type prepareDeadlineStore interface {
+	ListWaitingPastDeadline(ctx context.Context) ([]model.DeltaPrepare, error)
+	CASPrepareStatus(ctx context.Context, id uuid.UUID, to string) error
+}
+
+type DeltaPrepareDeadline struct {
+	log        logrus.FieldLogger
+	deltaStore prepareDeadlineStore
+	fleetSvc   fleetservice.Service
+	deviceSvc  deviceservice.Service
+	eventSvc   eventservice.Service
+}
+
+func NewDeltaPrepareDeadline(log logrus.FieldLogger, deltaStore deltastore.Store, fleetSvc fleetservice.Service, deviceSvc deviceservice.Service, eventSvc eventservice.Service) *DeltaPrepareDeadline {
+	return &DeltaPrepareDeadline{
+		log:        log,
+		deltaStore: deltaStore,
+		fleetSvc:   fleetSvc,
+		deviceSvc:  deviceSvc,
+		eventSvc:   eventSvc,
+	}
+}
+
+func (t *DeltaPrepareDeadline) Poll(ctx context.Context) {
+	t.log.Info("Running DeltaPrepareDeadline Polling")
+	rows, err := t.deltaStore.ListWaitingPastDeadline(ctx)
+	if err != nil {
+		t.log.WithError(err).Error("listing waiting delta prepares past deadline")
+		return
+	}
+	for i := range rows {
+		if err := t.failExpired(ctx, &rows[i]); err != nil {
+			t.log.WithError(err).Errorf("failing expired delta prepare %s", rows[i].ID)
+		}
+	}
+}
+
+func (t *DeltaPrepareDeadline) failExpired(ctx context.Context, prep *model.DeltaPrepare) error {
+	if err := t.deltaStore.CASPrepareStatus(ctx, prep.ID, model.DeltaPrepareFailed); err != nil {
+		if errors.Is(err, flterrors.ErrNoRowsUpdated) {
+			return nil
+		}
+		return err
+	}
+	matches, err := t.identityMatches(ctx, prep)
+	if err != nil {
+		return err
+	}
+	if !matches {
+		return nil
+	}
+	if err := t.clearPreparing(ctx, prep); err != nil {
+		return err
+	}
+	return t.emitResume(ctx, prep)
+}
+
+func (t *DeltaPrepareDeadline) identityMatches(ctx context.Context, prep *model.DeltaPrepare) (bool, error) {
+	switch prep.Kind {
+	case domain.FleetKind:
+		fleet, status := t.fleetSvc.GetFleet(ctx, prep.OrgID, prep.Name, domain.GetFleetParams{})
+		if status.Code != http.StatusOK {
+			return false, fmt.Errorf("getting fleet %s: %s", prep.Name, status.Message)
+		}
+		live := liveFleetTemplateVersion(fleet)
+		return equalStringPtr(prep.TemplateVersion, live), nil
+	case domain.DeviceKind:
+		device, status := t.deviceSvc.GetDevice(ctx, prep.OrgID, prep.Name)
+		if status.Code != http.StatusOK {
+			return false, fmt.Errorf("getting device %s: %s", prep.Name, status.Message)
+		}
+		return equalInt64Ptr(prep.SpecResourceVersion, device.Metadata.Generation), nil
+	default:
+		return false, fmt.Errorf("unsupported prepare kind %q", prep.Kind)
+	}
+}
+
+func (t *DeltaPrepareDeadline) emitResume(ctx context.Context, prep *model.DeltaPrepare) error {
+	switch prep.Kind {
+	case domain.FleetKind:
+		return t.emitFleetResume(ctx, prep)
+	case domain.DeviceKind:
+		t.eventSvc.CreateEvent(ctx, prep.OrgID, domain.GetBaseEvent(ctx, domain.DeviceKind, prep.Name, domain.EventReasonDeltaGenerationCompleted, "Delta generation completed.", nil))
+		return nil
+	default:
+		return fmt.Errorf("unsupported prepare kind %q", prep.Kind)
+	}
+}
+
+func (t *DeltaPrepareDeadline) emitFleetResume(ctx context.Context, prep *model.DeltaPrepare) error {
+	fleet, status := t.fleetSvc.GetFleet(ctx, prep.OrgID, prep.Name, domain.GetFleetParams{})
+	if status.Code != http.StatusOK {
+		return fmt.Errorf("getting fleet %s: %s", prep.Name, status.Message)
+	}
+	tv := lo.FromPtr(prep.TemplateVersion)
+	if tv == "" {
+		tv = lo.FromPtr(liveFleetTemplateVersion(fleet))
+	}
+	status = t.fleetSvc.UpdateFleetAnnotations(ctx, prep.OrgID, prep.Name, map[string]string{
+		domain.FleetAnnotationTemplateVersion: tv,
+	}, nil)
+	if status.Code != http.StatusOK {
+		return fmt.Errorf("setting fleet template version annotation: %s", status.Message)
+	}
+	if err := t.deviceSvc.SetOutOfDate(ctx, prep.OrgID, util.ResourceOwner(domain.FleetKind, prep.Name)); err != nil {
+		return err
+	}
+	immediate := fleet.Spec.RolloutPolicy == nil || fleet.Spec.RolloutPolicy.DeviceSelection == nil
+	t.eventSvc.CreateEvent(ctx, prep.OrgID, common.GetFleetRolloutStartedEvent(ctx, tv, prep.Name, immediate, false))
+	return nil
+}
+
+func (t *DeltaPrepareDeadline) clearPreparing(ctx context.Context, prep *model.DeltaPrepare) error {
+	switch prep.Kind {
+	case domain.FleetKind:
+		fleet, status := t.fleetSvc.GetFleet(ctx, prep.OrgID, prep.Name, domain.GetFleetParams{})
+		if status.Code != http.StatusOK {
+			return fmt.Errorf("getting fleet %s: %s", prep.Name, status.Message)
+		}
+		if fleet.Status == nil {
+			return nil
+		}
+		domain.RemoveStatusCondition(&fleet.Status.Conditions, domain.ConditionTypeFleetDeltaPreparing)
+		fleet.Status.DeltaGeneration = nil
+		_, status = t.fleetSvc.ReplaceFleetStatus(ctx, prep.OrgID, prep.Name, *fleet)
+		if status.Code != http.StatusOK {
+			return fmt.Errorf("clearing fleet preparing status: %s", status.Message)
+		}
+		return nil
+	case domain.DeviceKind:
+		device, status := t.deviceSvc.GetDevice(ctx, prep.OrgID, prep.Name)
+		if status.Code != http.StatusOK {
+			return fmt.Errorf("getting device %s: %s", prep.Name, status.Message)
+		}
+		if device.Status == nil {
+			return nil
+		}
+		domain.RemoveStatusCondition(&device.Status.Conditions, domain.ConditionTypeDeviceDeltaPreparing)
+		device.Status.DeltaGeneration = nil
+		_, status = t.deviceSvc.ReplaceDeviceStatus(ctx, prep.OrgID, prep.Name, *device, false)
+		if status.Code != http.StatusOK {
+			return fmt.Errorf("clearing device preparing status: %s", status.Message)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported prepare kind %q", prep.Kind)
+	}
+}
+
+func liveFleetTemplateVersion(fleet *domain.Fleet) *string {
+	if fleet == nil || fleet.Metadata.Annotations == nil {
+		return nil
+	}
+	tv, ok := (*fleet.Metadata.Annotations)[domain.FleetAnnotationTemplateVersion]
+	if !ok || tv == "" {
+		return nil
+	}
+	return &tv
+}
+
+func equalStringPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func equalInt64Ptr(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}

--- a/internal/tasks/delta_prepare_deadline.go
+++ b/internal/tasks/delta_prepare_deadline.go
@@ -13,6 +13,7 @@ import (
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	eventservice "github.com/flightctl/flightctl/internal/service/event"
 	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/internal/util"
@@ -33,15 +34,17 @@ type DeltaPrepareDeadline struct {
 	deltaStore prepareDeadlineStore
 	fleetSvc   fleetservice.Service
 	deviceSvc  deviceservice.Service
+	tvSvc      templateversionservice.Service
 	eventSvc   eventservice.Service
 }
 
-func NewDeltaPrepareDeadline(log logrus.FieldLogger, deltaStore deltastore.Store, fleetSvc fleetservice.Service, deviceSvc deviceservice.Service, eventSvc eventservice.Service) *DeltaPrepareDeadline {
+func NewDeltaPrepareDeadline(log logrus.FieldLogger, deltaStore deltastore.Store, fleetSvc fleetservice.Service, deviceSvc deviceservice.Service, tvSvc templateversionservice.Service, eventSvc eventservice.Service) *DeltaPrepareDeadline {
 	return &DeltaPrepareDeadline{
 		log:        log,
 		deltaStore: deltaStore,
 		fleetSvc:   fleetSvc,
 		deviceSvc:  deviceSvc,
+		tvSvc:      tvSvc,
 		eventSvc:   eventSvc,
 	}
 }
@@ -83,12 +86,17 @@ func (t *DeltaPrepareDeadline) failExpired(ctx context.Context, prep *model.Delt
 func (t *DeltaPrepareDeadline) identityMatches(ctx context.Context, prep *model.DeltaPrepare) (bool, error) {
 	switch prep.Kind {
 	case domain.FleetKind:
-		fleet, status := t.fleetSvc.GetFleet(ctx, prep.OrgID, prep.Name, domain.GetFleetParams{})
-		if status.Code != http.StatusOK {
-			return false, fmt.Errorf("getting fleet %s: %s", prep.Name, status.Message)
+		if t.tvSvc == nil {
+			return false, fmt.Errorf("template version service is required")
 		}
-		live := liveFleetTemplateVersion(fleet)
-		return equalStringPtr(prep.TemplateVersion, live), nil
+		tv, status := t.tvSvc.GetLatestTemplateVersion(ctx, prep.OrgID, prep.Name)
+		if status.Code != http.StatusOK {
+			if status.Code == http.StatusNotFound {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting latest template version for fleet %s: %s", prep.Name, status.Message)
+		}
+		return equalStringPtr(prep.TemplateVersion, tv.Metadata.Name), nil
 	case domain.DeviceKind:
 		device, status := t.deviceSvc.GetDevice(ctx, prep.OrgID, prep.Name)
 		if status.Code != http.StatusOK {

--- a/internal/tasks/delta_prepare_deadline_test.go
+++ b/internal/tasks/delta_prepare_deadline_test.go
@@ -1,0 +1,151 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/domain"
+	"github.com/flightctl/flightctl/internal/flterrors"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+)
+
+type fakeDeadlineStore struct {
+	waiting []model.DeltaPrepare
+	casTo   map[uuid.UUID]string
+}
+
+func (f *fakeDeadlineStore) ListWaitingPastDeadline(context.Context) ([]model.DeltaPrepare, error) {
+	out := make([]model.DeltaPrepare, len(f.waiting))
+	copy(out, f.waiting)
+	return out, nil
+}
+
+func (f *fakeDeadlineStore) CASPrepareStatus(_ context.Context, id uuid.UUID, to string) error {
+	for i := range f.waiting {
+		if f.waiting[i].ID != id {
+			continue
+		}
+		if f.waiting[i].Status != model.DeltaPrepareWaiting {
+			return flterrors.ErrNoRowsUpdated
+		}
+		f.waiting[i].Status = to
+		if f.casTo == nil {
+			f.casTo = map[uuid.UUID]string{}
+		}
+		f.casTo[id] = to
+		return nil
+	}
+	return flterrors.ErrNoRowsUpdated
+}
+
+type deadlineEventRecorder struct {
+	events []*domain.Event
+}
+
+func (e *deadlineEventRecorder) CreateEvent(_ context.Context, _ uuid.UUID, event *domain.Event) {
+	if event == nil {
+		return
+	}
+	cp := *event
+	e.events = append(e.events, &cp)
+}
+
+func (e *deadlineEventRecorder) ListEvents(context.Context, uuid.UUID, domain.ListEventsParams) (*domain.EventList, domain.Status) {
+	return nil, domain.StatusOK()
+}
+
+func (e *deadlineEventRecorder) DeleteEventsOlderThan(context.Context, time.Time) (int64, domain.Status) {
+	return 0, domain.StatusOK()
+}
+
+func TestDeltaPrepareDeadlinePoll(t *testing.T) {
+	orgId := uuid.New()
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	t.Run("When a waiting prepare is past deadline it should CAS-fail and emit FleetRolloutStarted", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		fleetSvc := fleetservice.NewMockService(ctrl)
+		deviceSvc := deviceservice.NewMockService(ctrl)
+		fleet := &domain.Fleet{
+			Metadata: domain.ObjectMeta{
+				Name:        lo.ToPtr("fleet-1"),
+				Annotations: &map[string]string{domain.FleetAnnotationTemplateVersion: "tv-1"},
+			},
+			Spec:   domain.FleetSpec{},
+			Status: &domain.FleetStatus{},
+		}
+		fleetSvc.EXPECT().GetFleet(gomock.Any(), orgId, "fleet-1", gomock.Any()).Return(fleet, domain.StatusOK()).AnyTimes()
+		fleetSvc.EXPECT().UpdateFleetAnnotations(gomock.Any(), orgId, "fleet-1", gomock.Any(), gomock.Any()).Return(domain.StatusOK())
+		fleetSvc.EXPECT().ReplaceFleetStatus(gomock.Any(), orgId, "fleet-1", gomock.Any()).Return(fleet, domain.StatusOK())
+		deviceSvc.EXPECT().SetOutOfDate(gomock.Any(), orgId, gomock.Any()).Return(nil)
+		rec := &deadlineEventRecorder{}
+		prep := model.DeltaPrepare{
+			ID:              uuid.New(),
+			OrgID:           orgId,
+			Kind:            domain.FleetKind,
+			Name:            "fleet-1",
+			TemplateVersion: lo.ToPtr("tv-1"),
+			Status:          model.DeltaPrepareWaiting,
+			Deadline:        lo.ToPtr(time.Now().Add(-time.Minute)),
+		}
+		store := &fakeDeadlineStore{waiting: []model.DeltaPrepare{prep}}
+		task := &DeltaPrepareDeadline{log: log, deltaStore: store, fleetSvc: fleetSvc, deviceSvc: deviceSvc, eventSvc: rec}
+
+		task.Poll(context.Background())
+		assert.Equal(t, model.DeltaPrepareFailed, store.waiting[0].Status)
+		require.Len(t, rec.events, 1)
+		assert.Equal(t, domain.EventReasonFleetRolloutStarted, rec.events[0].Reason)
+	})
+
+	t.Run("When the list is empty it should not emit", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		rec := &deadlineEventRecorder{}
+		task := &DeltaPrepareDeadline{
+			log:        log,
+			deltaStore: &fakeDeadlineStore{},
+			fleetSvc:   fleetservice.NewMockService(ctrl),
+			deviceSvc:  deviceservice.NewMockService(ctrl),
+			eventSvc:   rec,
+		}
+		task.Poll(context.Background())
+		assert.Empty(t, rec.events)
+	})
+
+	t.Run("When live TV is stale it should CAS-fail without emit", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		fleetSvc := fleetservice.NewMockService(ctrl)
+		deviceSvc := deviceservice.NewMockService(ctrl)
+		fleet := &domain.Fleet{
+			Metadata: domain.ObjectMeta{
+				Name:        lo.ToPtr("fleet-1"),
+				Annotations: &map[string]string{domain.FleetAnnotationTemplateVersion: "tv-2"},
+			},
+			Spec: domain.FleetSpec{},
+		}
+		fleetSvc.EXPECT().GetFleet(gomock.Any(), orgId, "fleet-1", gomock.Any()).Return(fleet, domain.StatusOK())
+		rec := &deadlineEventRecorder{}
+		prep := model.DeltaPrepare{
+			ID:              uuid.New(),
+			OrgID:           orgId,
+			Kind:            domain.FleetKind,
+			Name:            "fleet-1",
+			TemplateVersion: lo.ToPtr("tv-1"),
+			Status:          model.DeltaPrepareWaiting,
+		}
+		store := &fakeDeadlineStore{waiting: []model.DeltaPrepare{prep}}
+		task := &DeltaPrepareDeadline{log: log, deltaStore: store, fleetSvc: fleetSvc, deviceSvc: deviceSvc, eventSvc: rec}
+		task.Poll(context.Background())
+		assert.Equal(t, model.DeltaPrepareFailed, store.waiting[0].Status)
+		assert.Empty(t, rec.events)
+	})
+}

--- a/internal/tasks/delta_prepare_deadline_test.go
+++ b/internal/tasks/delta_prepare_deadline_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flightctl/flightctl/internal/flterrors"
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -88,6 +89,8 @@ func TestDeltaPrepareDeadlinePoll(t *testing.T) {
 		fleetSvc.EXPECT().UpdateFleetAnnotations(gomock.Any(), orgId, "fleet-1", gomock.Any(), gomock.Any()).Return(domain.StatusOK())
 		fleetSvc.EXPECT().ReplaceFleetStatus(gomock.Any(), orgId, "fleet-1", gomock.Any()).Return(fleet, domain.StatusOK())
 		deviceSvc.EXPECT().SetOutOfDate(gomock.Any(), orgId, gomock.Any()).Return(nil)
+		tvSvc := templateversionservice.NewMockService(ctrl)
+		tvSvc.EXPECT().GetLatestTemplateVersion(gomock.Any(), orgId, "fleet-1").Return(&domain.TemplateVersion{Metadata: domain.ObjectMeta{Name: lo.ToPtr("tv-1")}}, domain.StatusOK())
 		rec := &deadlineEventRecorder{}
 		prep := model.DeltaPrepare{
 			ID:              uuid.New(),
@@ -99,7 +102,7 @@ func TestDeltaPrepareDeadlinePoll(t *testing.T) {
 			Deadline:        lo.ToPtr(time.Now().Add(-time.Minute)),
 		}
 		store := &fakeDeadlineStore{waiting: []model.DeltaPrepare{prep}}
-		task := &DeltaPrepareDeadline{log: log, deltaStore: store, fleetSvc: fleetSvc, deviceSvc: deviceSvc, eventSvc: rec}
+		task := &DeltaPrepareDeadline{log: log, deltaStore: store, fleetSvc: fleetSvc, deviceSvc: deviceSvc, tvSvc: tvSvc, eventSvc: rec}
 
 		task.Poll(context.Background())
 		assert.Equal(t, model.DeltaPrepareFailed, store.waiting[0].Status)
@@ -132,7 +135,9 @@ func TestDeltaPrepareDeadlinePoll(t *testing.T) {
 			},
 			Spec: domain.FleetSpec{},
 		}
-		fleetSvc.EXPECT().GetFleet(gomock.Any(), orgId, "fleet-1", gomock.Any()).Return(fleet, domain.StatusOK())
+		fleetSvc.EXPECT().GetFleet(gomock.Any(), orgId, "fleet-1", gomock.Any()).Return(fleet, domain.StatusOK()).AnyTimes()
+		tvSvc := templateversionservice.NewMockService(ctrl)
+		tvSvc.EXPECT().GetLatestTemplateVersion(gomock.Any(), orgId, "fleet-1").Return(&domain.TemplateVersion{Metadata: domain.ObjectMeta{Name: lo.ToPtr("tv-2")}}, domain.StatusOK())
 		rec := &deadlineEventRecorder{}
 		prep := model.DeltaPrepare{
 			ID:              uuid.New(),
@@ -143,7 +148,7 @@ func TestDeltaPrepareDeadlinePoll(t *testing.T) {
 			Status:          model.DeltaPrepareWaiting,
 		}
 		store := &fakeDeadlineStore{waiting: []model.DeltaPrepare{prep}}
-		task := &DeltaPrepareDeadline{log: log, deltaStore: store, fleetSvc: fleetSvc, deviceSvc: deviceSvc, eventSvc: rec}
+		task := &DeltaPrepareDeadline{log: log, deltaStore: store, fleetSvc: fleetSvc, deviceSvc: deviceSvc, tvSvc: tvSvc, eventSvc: rec}
 		task.Poll(context.Background())
 		assert.Equal(t, model.DeltaPrepareFailed, store.waiting[0].Status)
 		assert.Empty(t, rec.events)

--- a/internal/tasks/fleet_validate.go
+++ b/internal/tasks/fleet_validate.go
@@ -47,7 +47,7 @@ type FleetValidateLogic struct {
 	orgId              uuid.UUID
 	event              domain.Event
 	templateConfig     *[]domain.ConfigProviderSpec
-	workerClient       worker_client.WorkerClient
+	WorkerClient       worker_client.WorkerClient
 }
 
 func NewFleetValidateLogic(log logrus.FieldLogger, fleetSvc fleetservice.Service, templateversionSvc templateversionservice.Service, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, k8sClient k8sclient.K8SClient, orgId uuid.UUID, event domain.Event) FleetValidateLogic {
@@ -119,7 +119,7 @@ func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Co
 }
 
 func (t *FleetValidateLogic) emitPrepareDeltas(ctx context.Context, fleetName, tvName string) error {
-	if t.workerClient == nil {
+	if t.WorkerClient == nil {
 		return fmt.Errorf("worker client is required to emit PrepareDeltas")
 	}
 	details := domain.PrepareDeltasDetails{
@@ -130,7 +130,7 @@ func (t *FleetValidateLogic) emitPrepareDeltas(ctx context.Context, fleetName, t
 	if err := eventDetails.FromPrepareDeltasDetails(details); err != nil {
 		return err
 	}
-	t.workerClient.EmitEvent(ctx, t.orgId, domain.GetBaseEvent(ctx, domain.FleetKind, fleetName, domain.EventReasonPrepareDeltas, "Preparing OS image deltas", &eventDetails))
+	t.WorkerClient.EmitEvent(ctx, t.orgId, domain.GetBaseEvent(ctx, domain.FleetKind, fleetName, domain.EventReasonPrepareDeltas, "Preparing OS image deltas", &eventDetails))
 	return nil
 }
 

--- a/internal/tasks/fleet_validate.go
+++ b/internal/tasks/fleet_validate.go
@@ -15,6 +15,7 @@ import (
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
 	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	"github.com/flightctl/flightctl/internal/util"
+	"github.com/flightctl/flightctl/internal/worker_client"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -36,20 +37,6 @@ import (
 // This design avoids unnecessary object creation, ensures consistency, and allows
 // safe reprocessing of the task without side effects.
 
-func fleetValidate(ctx context.Context, orgId uuid.UUID, event domain.Event, fleetSvc fleetservice.Service, templateversionSvc templateversionservice.Service, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, k8sClient k8sclient.K8SClient, log logrus.FieldLogger) error {
-	logic := NewFleetValidateLogic(log, fleetSvc, templateversionSvc, deviceSvc, repositorySvc, k8sClient, orgId, event)
-	switch {
-	case event.InvolvedObject.Kind == domain.FleetKind:
-		err := logic.CreateNewTemplateVersionIfFleetValid(ctx)
-		if err != nil {
-			log.Errorf("failed validating fleet %s/%s: %v", orgId, event.InvolvedObject.Name, err)
-		}
-	default:
-		log.Errorf("FleetValidate called with unexpected kind %s and reason %s", event.InvolvedObject.Kind, event.Reason)
-	}
-	return nil
-}
-
 type FleetValidateLogic struct {
 	log                logrus.FieldLogger
 	fleetSvc           fleetservice.Service
@@ -60,6 +47,7 @@ type FleetValidateLogic struct {
 	orgId              uuid.UUID
 	event              domain.Event
 	templateConfig     *[]domain.ConfigProviderSpec
+	workerClient       worker_client.WorkerClient
 }
 
 func NewFleetValidateLogic(log logrus.FieldLogger, fleetSvc fleetservice.Service, templateversionSvc templateversionservice.Service, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, k8sClient k8sclient.K8SClient, orgId uuid.UUID, event domain.Event) FleetValidateLogic {
@@ -123,21 +111,27 @@ func (t *FleetValidateLogic) CreateNewTemplateVersionIfFleetValid(ctx context.Co
 		return t.setStatus(ctx, fmt.Errorf("failed creating templateVersion for valid fleet: %s", status.Message))
 	}
 
-	annotations := map[string]string{
-		domain.FleetAnnotationTemplateVersion: *tv.Metadata.Name,
-	}
-	status = t.fleetSvc.UpdateFleetAnnotations(ctx, t.orgId, *fleet.Metadata.Name, annotations, nil)
-	if status.Code != http.StatusOK {
-		return t.setStatus(ctx, fmt.Errorf("failed setting fleet annotation with newly-created templateVersion: %s", status.Message))
-	}
-
-	err := t.deviceSvc.SetOutOfDate(ctx, t.orgId, util.ResourceOwner(domain.FleetKind, *fleet.Metadata.Name))
-	if err != nil {
-		// Warn only.  It is better to continue processing than to fail the fleet validation and stop rollour.
-		t.log.Warnf("failed marking devices out-of-date after new template version created: %v", err)
+	if err := t.emitPrepareDeltas(ctx, *fleet.Metadata.Name, *tv.Metadata.Name); err != nil {
+		return t.setStatus(ctx, err)
 	}
 
 	return t.setStatus(ctx, nil)
+}
+
+func (t *FleetValidateLogic) emitPrepareDeltas(ctx context.Context, fleetName, tvName string) error {
+	if t.workerClient == nil {
+		return fmt.Errorf("worker client is required to emit PrepareDeltas")
+	}
+	details := domain.PrepareDeltasDetails{
+		DetailType:      domain.PrepareDeltasDetailsDetailType("PrepareDeltas"),
+		TemplateVersion: &tvName,
+	}
+	var eventDetails domain.EventDetails
+	if err := eventDetails.FromPrepareDeltasDetails(details); err != nil {
+		return err
+	}
+	t.workerClient.EmitEvent(ctx, t.orgId, domain.GetBaseEvent(ctx, domain.FleetKind, fleetName, domain.EventReasonPrepareDeltas, "Preparing OS image deltas", &eventDetails))
+	return nil
 }
 
 func (t *FleetValidateLogic) setStatus(ctx context.Context, validationErr error) error {

--- a/internal/tasks/fleet_validate_test.go
+++ b/internal/tasks/fleet_validate_test.go
@@ -13,46 +13,32 @@ import (
 	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
 )
 
-func TestFleetValidateLogic_CreateNewTemplateVersionIfFleetValid_ImmediateRollout(t *testing.T) {
+func TestFleetValidateLogic_CreateNewTemplateVersionIfFleetValid_EmitsPrepareDeltas(t *testing.T) {
 	tests := []struct {
-		name              string
-		rolloutPolicy     *domain.RolloutPolicy
-		expectedImmediate bool
-		description       string
+		name          string
+		rolloutPolicy *domain.RolloutPolicy
 	}{
 		{
-			name:              "NoRolloutPolicy",
-			rolloutPolicy:     nil,
-			expectedImmediate: true,
-			description:       "immediateRollout should be true when RolloutPolicy is nil",
+			name:          "When there is no rollout policy it should emit PrepareDeltas",
+			rolloutPolicy: nil,
 		},
 		{
-			name: "RolloutPolicyWithoutDeviceSelection",
-			rolloutPolicy: &domain.RolloutPolicy{
-				DeviceSelection: nil,
-			},
-			expectedImmediate: true,
-			description:       "immediateRollout should be true when RolloutPolicy exists but DeviceSelection is nil",
-		},
-		{
-			name: "RolloutPolicyWithDeviceSelection",
+			name: "When DeviceSelection is set it should emit PrepareDeltas",
 			rolloutPolicy: &domain.RolloutPolicy{
 				DeviceSelection: &domain.RolloutDeviceSelection{},
 			},
-			expectedImmediate: false,
-			description:       "immediateRollout should be false when RolloutPolicy.DeviceSelection exists",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -61,6 +47,7 @@ func TestFleetValidateLogic_CreateNewTemplateVersionIfFleetValid_ImmediateRollou
 			event := createTestEvent(domain.FleetKind, "some-reason", fleetName)
 			orgId := uuid.New()
 			log := logrus.New()
+			emit := &prepareDeltasEmitter{}
 
 			mockFleetSvc := fleetservice.NewMockService(ctrl)
 			mockTemplateVersionSvc := templateversionservice.NewMockService(ctrl)
@@ -68,44 +55,44 @@ func TestFleetValidateLogic_CreateNewTemplateVersionIfFleetValid_ImmediateRollou
 			mockRepositorySvc := repositoryservice.NewMockService(ctrl)
 			mockK8SClient := k8sclient.NewMockK8SClient(ctrl)
 
-			// Mock GetFleet to return our test fleet
 			mockFleetSvc.EXPECT().GetFleet(gomock.Any(), gomock.Any(), fleetName, gomock.Any()).Return(fleet, domain.Status{Code: http.StatusOK})
-
-			// Mock OverwriteFleetRepositoryRefs to succeed
 			mockFleetSvc.EXPECT().OverwriteFleetRepositoryRefs(gomock.Any(), gomock.Any(), fleetName, gomock.Any()).Return(domain.Status{Code: http.StatusOK})
-
-			// Mock CreateTemplateVersion to capture the immediateRollout parameter
-			var capturedImmediateRollout bool
 			mockTemplateVersionSvc.EXPECT().CreateTemplateVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ctx context.Context, orgId uuid.UUID, tv domain.TemplateVersion, immediateRollout bool) (*domain.TemplateVersion, domain.Status) {
-					capturedImmediateRollout = immediateRollout
 					return &domain.TemplateVersion{
 						Metadata: domain.ObjectMeta{
-							Name: &[]string{"test-tv"}[0],
+							Name: lo.ToPtr("test-tv"),
 						},
 					}, domain.Status{Code: http.StatusCreated}
 				})
-
-			// Mock UpdateFleetAnnotations to succeed
-			mockFleetSvc.EXPECT().UpdateFleetAnnotations(gomock.Any(), gomock.Any(), fleetName, gomock.Any(), gomock.Any()).Return(domain.Status{Code: http.StatusOK})
-
-			// Mock UpdateToOutOfDateByOwner to succeed
-			mockDeviceSvc.EXPECT().SetOutOfDate(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-
-			// Mock UpdateFleetConditions to succeed
 			mockFleetSvc.EXPECT().UpdateFleetConditions(gomock.Any(), gomock.Any(), fleetName, gomock.Any()).Return(domain.Status{Code: http.StatusOK})
 
-			// Create FleetValidateLogic instance
 			logic := NewFleetValidateLogic(log, mockFleetSvc, mockTemplateVersionSvc, mockDeviceSvc, mockRepositorySvc, mockK8SClient, orgId, event)
+			logic.workerClient = emit
 
-			// Execute
 			err := logic.CreateNewTemplateVersionIfFleetValid(context.Background())
-
-			// Assert
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedImmediate, capturedImmediateRollout, tt.description)
+			require.Len(t, emit.events, 1)
+			assert.Equal(t, domain.EventReasonPrepareDeltas, emit.events[0].Reason)
+			assert.Equal(t, domain.FleetKind, emit.events[0].InvolvedObject.Kind)
+			assert.Equal(t, fleetName, emit.events[0].InvolvedObject.Name)
+			details, err := emit.events[0].Details.AsPrepareDeltasDetails()
+			require.NoError(t, err)
+			assert.Equal(t, "test-tv", lo.FromPtr(details.TemplateVersion))
 		})
 	}
+}
+
+type prepareDeltasEmitter struct {
+	events []*domain.Event
+}
+
+func (e *prepareDeltasEmitter) EmitEvent(_ context.Context, _ uuid.UUID, event *domain.Event) {
+	if event == nil {
+		return
+	}
+	cp := *event
+	e.events = append(e.events, &cp)
 }
 
 func TestGenerateTemplateVersionName(t *testing.T) {

--- a/internal/tasks/fleet_validate_test.go
+++ b/internal/tasks/fleet_validate_test.go
@@ -68,7 +68,7 @@ func TestFleetValidateLogic_CreateNewTemplateVersionIfFleetValid_EmitsPrepareDel
 			mockFleetSvc.EXPECT().UpdateFleetConditions(gomock.Any(), gomock.Any(), fleetName, gomock.Any()).Return(domain.Status{Code: http.StatusOK})
 
 			logic := NewFleetValidateLogic(log, mockFleetSvc, mockTemplateVersionSvc, mockDeviceSvc, mockRepositorySvc, mockK8SClient, orgId, event)
-			logic.workerClient = emit
+			logic.WorkerClient = emit
 
 			err := logic.CreateNewTemplateVersionIfFleetValid(context.Background())
 			require.NoError(t, err)

--- a/internal/worker_server/server.go
+++ b/internal/worker_server/server.go
@@ -132,7 +132,22 @@ func (s *Server) Run(ctx context.Context) error {
 		s.log.WithField("pkg", "encryption-migration"),
 	)
 
-	if err = tasks.LaunchConsumers(ctx, s.queuesProvider, fleetSvc, templateVersionSvc, deviceSvc, dependencyrefSvc, repositorySvc, catalogSvc, eventSvc, s.k8sClient, kvStore, s.cfg, 1, 1, s.workerMetrics, encryptionMigrator, publisher); err != nil {
+	if err = tasks.LaunchConsumers(ctx, s.queuesProvider, tasks.TaskConsumer{
+		FleetSvc:           fleetSvc,
+		TemplateversionSvc: templateVersionSvc,
+		DeviceSvc:          deviceSvc,
+		DependencyrefSvc:   dependencyrefSvc,
+		RepositorySvc:      repositorySvc,
+		CatalogSvc:         catalogSvc,
+		EventSvc:           eventSvc,
+		K8sClient:          s.k8sClient,
+		KVStore:            kvStore,
+		Cfg:                s.cfg,
+		WorkerMetrics:      s.workerMetrics,
+		EncryptionMigrator: encryptionMigrator,
+		QueuePublisher:     publisher,
+		WorkerClient:       workerClient,
+	}, 1, 1); err != nil {
 		s.log.WithError(err).Error("failed to launch consumers")
 		return err
 	}

--- a/test/integration/delta_worker/prepare_test.go
+++ b/test/integration/delta_worker/prepare_test.go
@@ -9,18 +9,25 @@ import (
 	"github.com/flightctl/flightctl/internal/config"
 	deltaworker "github.com/flightctl/flightctl/internal/delta_worker"
 	"github.com/flightctl/flightctl/internal/domain"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	"github.com/flightctl/flightctl/internal/service/events"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	"github.com/flightctl/flightctl/internal/store"
 	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
+	eventstore "github.com/flightctl/flightctl/internal/store/event"
 	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
 	"github.com/flightctl/flightctl/internal/store/model"
 	organizationstore "github.com/flightctl/flightctl/internal/store/organization"
 	repositorystore "github.com/flightctl/flightctl/internal/store/repository"
 	"github.com/flightctl/flightctl/internal/store/selector"
+	tvstore "github.com/flightctl/flightctl/internal/store/templateversion"
 	"github.com/flightctl/flightctl/internal/tasks"
 	"github.com/flightctl/flightctl/internal/util"
 	"github.com/flightctl/flightctl/internal/worker_client"
 	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/queues"
 	testutil "github.com/flightctl/flightctl/test/util"
 	"github.com/flightctl/flightctl/test/util/testdb"
 	"github.com/google/uuid"
@@ -28,6 +35,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"go.uber.org/mock/gomock"
 	"gorm.io/gorm"
 )
 
@@ -170,6 +178,89 @@ var _ = Describe("PrepareDeltas persist", func() {
 			Expect(payload["imageRepository"]).To(Equal(repoName))
 			Expect(payload["sourceDigest"]).To(Equal(srcDigest))
 			Expect(payload["targetDigest"]).To(Equal(tgtDigest))
+		})
+	})
+
+	When("the last joined generation pair becomes terminal", func() {
+		It("should complete the waiting prepare and emit FleetRolloutStarted", func() {
+			const (
+				fleetName = "fleet-resume"
+				tvName    = "tv-resume"
+				repoName  = "quay.io/acme/os"
+				srcDigest = "sha256:src"
+				tgtDigest = "sha256:tgt"
+			)
+
+			testutil.CreateTestFleet(ctx, fleets, orgId, fleetName, nil, nil)
+			tvs := tvstore.NewTemplateVersionStore(db, log.WithField("pkg", "tv-store"))
+			Expect(testutil.CreateTestTemplateVersion(ctx, tvs, orgId, fleetName, tvName, &domain.TemplateVersionStatus{
+				Os: &domain.DeviceOsSpec{Image: "quay.io/acme/os:v2"},
+			})).To(Succeed())
+
+			ctrl := gomock.NewController(GinkgoT())
+			DeferCleanup(ctrl.Finish)
+			producer := queues.NewMockQueueProducer(ctrl)
+			producer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			eventsSvc := events.NewServiceHandler(eventstore.NewEventStore(db, log.WithField("pkg", "event-store")), worker_client.NewWorkerClient(producer, log), log)
+			fleetSvc := fleetservice.NewServiceHandler(fleets, nil, eventsSvc, log)
+			deviceSvc := deviceservice.NewDeviceServiceHandler(devices, nil, fleets, eventsSvc, nil, "", log)
+			tvSvc := templateversionservice.NewServiceHandler(tvs, nil, eventsSvc, log)
+
+			key := deltastore.GenerationKey{
+				OrgID:           orgId,
+				ImageRepository: repoName,
+				SourceDigest:    srcDigest,
+				TargetDigest:    tgtDigest,
+			}
+			_, err := deltaStore.InsertGenerations(ctx, []*model.DeltaGeneration{{
+				OrgID:           orgId,
+				ImageRepository: repoName,
+				SourceDigest:    srcDigest,
+				TargetDigest:    tgtDigest,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+			tv := tvName
+			prep := &model.DeltaPrepare{
+				OrgID:           orgId,
+				Kind:            domain.FleetKind,
+				Name:            fleetName,
+				TemplateVersion: &tv,
+			}
+			Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+			Expect(deltaStore.InsertPrepareGenerations(ctx, prep.ID, []deltastore.GenerationKey{key})).To(Succeed())
+
+			gen, err := deltaStore.GetGeneration(ctx, key)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(deltaStore.CASGeneration(ctx, key, gen.ResourceVersion, deltastore.GenerationCAS{
+				Status: model.DeltaGenerationSucceeded,
+			})).To(Succeed())
+
+			p := &deltaworker.Preparer{
+				Store:     deltaStore,
+				Events:    eventsSvc,
+				FleetSvc:  fleetSvc,
+				DeviceSvc: deviceSvc,
+				TVSvc:     tvSvc,
+				Status:    deltaworker.NewStorePreparingStatus(fleets, devices),
+			}
+			Expect(p.CompleteWaitingIfTerminal(ctx, key)).To(Succeed())
+
+			got, err := deltaStore.GetPrepare(ctx, prep.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal(model.DeltaPrepareComplete))
+
+			listed, err := eventstore.NewEventStore(db, log).List(ctx, orgId, store.ListParams{Limit: 100})
+			Expect(err).ToNot(HaveOccurred())
+			reasons := make([]domain.EventReason, 0, len(listed.Items))
+			for i := range listed.Items {
+				reasons = append(reasons, listed.Items[i].Reason)
+			}
+			Expect(reasons).To(ContainElement(domain.EventReasonFleetRolloutStarted))
+
+			fleet, err := fleets.Get(ctx, orgId, fleetName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fleet.Metadata.Annotations).ToNot(BeNil())
+			Expect((*fleet.Metadata.Annotations)[domain.FleetAnnotationTemplateVersion]).To(Equal(tvName))
 		})
 	})
 })

--- a/test/integration/periodic_checker/delta_prepare_deadline_test.go
+++ b/test/integration/periodic_checker/delta_prepare_deadline_test.go
@@ -1,0 +1,162 @@
+package periodic_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"github.com/flightctl/flightctl/internal/domain"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
+	eventservice "github.com/flightctl/flightctl/internal/service/event"
+	"github.com/flightctl/flightctl/internal/service/events"
+	fleetservice "github.com/flightctl/flightctl/internal/service/fleet"
+	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
+	"github.com/flightctl/flightctl/internal/store"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
+	devicestore "github.com/flightctl/flightctl/internal/store/device"
+	eventstore "github.com/flightctl/flightctl/internal/store/event"
+	fleetstore "github.com/flightctl/flightctl/internal/store/fleet"
+	"github.com/flightctl/flightctl/internal/store/model"
+	organizationstore "github.com/flightctl/flightctl/internal/store/organization"
+	tvstore "github.com/flightctl/flightctl/internal/store/templateversion"
+	"github.com/flightctl/flightctl/internal/tasks"
+	"github.com/flightctl/flightctl/internal/worker_client"
+	flightlog "github.com/flightctl/flightctl/pkg/log"
+	"github.com/flightctl/flightctl/pkg/queues"
+	testutil "github.com/flightctl/flightctl/test/util"
+	"github.com/flightctl/flightctl/test/util/testdb"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("Delta prepare deadline poll", func() {
+	var (
+		ctx        context.Context
+		orgId      uuid.UUID
+		cfg        *config.Config
+		dbName     string
+		db         *gorm.DB
+		deltaStore deltastore.Store
+		fleets     fleetstore.Store
+		devices    devicestore.Store
+		tvs        tvstore.Store
+		eventStore eventstore.Store
+		deadline   *tasks.DeltaPrepareDeadline
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		log := flightlog.InitLogs()
+		var err error
+		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)
+		Expect(err).NotTo(HaveOccurred())
+		deltaStore = deltastore.NewStore(db, log.WithField("pkg", "delta-store"))
+		fleets = fleetstore.NewFleetStore(db, log.WithField("pkg", "fleet-store"))
+		devices = devicestore.NewDeviceStore(db, log.WithField("pkg", "device-store"))
+		tvs = tvstore.NewTemplateVersionStore(db, log.WithField("pkg", "tv-store"))
+		eventStore = eventstore.NewEventStore(db, log.WithField("pkg", "event-store"))
+		orgs := organizationstore.NewOrganizationStore(db)
+		orgId = uuid.New()
+		Expect(testutil.CreateTestOrganization(ctx, orgs, orgId)).To(Succeed())
+
+		ctrl := gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+		producer := queues.NewMockQueueProducer(ctrl)
+		producer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		eventsSvc := events.NewServiceHandler(eventStore, worker_client.NewWorkerClient(producer, log), log)
+		deadline = tasks.NewDeltaPrepareDeadline(
+			log,
+			deltaStore,
+			fleetservice.NewServiceHandler(fleets, nil, eventsSvc, log),
+			deviceservice.NewDeviceServiceHandler(devices, nil, fleets, eventsSvc, nil, "", log),
+			templateversionservice.NewServiceHandler(tvs, nil, eventsSvc, log),
+			eventservice.NewServiceHandler(eventStore, eventsSvc),
+		)
+	})
+
+	AfterEach(func() {
+		Expect(testdb.DeleteTestDB(ctx, flightlog.InitLogs(), cfg, db, dbName)).To(Succeed())
+	})
+
+	eventReasons := func() []domain.EventReason {
+		listed, err := eventStore.List(ctx, orgId, store.ListParams{Limit: 100})
+		Expect(err).ToNot(HaveOccurred())
+		out := make([]domain.EventReason, 0, len(listed.Items))
+		for i := range listed.Items {
+			out = append(out, listed.Items[i].Reason)
+		}
+		return out
+	}
+
+	It("should fail a past-deadline waiting prepare and emit FleetRolloutStarted without changing generation status", func() {
+		const (
+			fleetName = "expired-fleet"
+			tvName    = "tv-expired"
+			repoName  = "quay.io/acme/os"
+		)
+		testutil.CreateTestFleet(ctx, fleets, orgId, fleetName, nil, nil)
+		Expect(testutil.CreateTestTemplateVersion(ctx, tvs, orgId, fleetName, tvName, nil)).To(Succeed())
+
+		key := deltastore.GenerationKey{
+			OrgID:           orgId,
+			ImageRepository: repoName,
+			SourceDigest:    "sha256:src",
+			TargetDigest:    "sha256:tgt",
+		}
+		_, err := deltaStore.InsertGenerations(ctx, []*model.DeltaGeneration{{
+			OrgID:           orgId,
+			ImageRepository: key.ImageRepository,
+			SourceDigest:    key.SourceDigest,
+			TargetDigest:    key.TargetDigest,
+			Status:          model.DeltaGenerationInProgress,
+		}})
+		Expect(err).ToNot(HaveOccurred())
+
+		past := time.Now().Add(-time.Hour)
+		tv := tvName
+		prep := &model.DeltaPrepare{
+			OrgID:           orgId,
+			Kind:            domain.FleetKind,
+			Name:            fleetName,
+			TemplateVersion: &tv,
+			Deadline:        &past,
+		}
+		Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+
+		deadline.Poll(ctx)
+
+		got, err := deltaStore.GetPrepare(ctx, prep.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got.Status).To(Equal(model.DeltaPrepareFailed))
+
+		gen, err := deltaStore.GetGeneration(ctx, key)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gen.Status).To(Equal(model.DeltaGenerationInProgress))
+
+		Expect(eventReasons()).To(ContainElement(domain.EventReasonFleetRolloutStarted))
+	})
+
+	It("should leave a waiting prepare with a null deadline waiting", func() {
+		const fleetName = "no-deadline"
+		testutil.CreateTestFleet(ctx, fleets, orgId, fleetName, nil, nil)
+		Expect(testutil.CreateTestTemplateVersion(ctx, tvs, orgId, fleetName, "tv-1", nil)).To(Succeed())
+		prep := &model.DeltaPrepare{
+			OrgID:           orgId,
+			Kind:            domain.FleetKind,
+			Name:            fleetName,
+			TemplateVersion: lo.ToPtr("tv-1"),
+		}
+		Expect(deltaStore.InsertPrepare(ctx, prep)).To(Succeed())
+
+		deadline.Poll(ctx)
+
+		got, err := deltaStore.GetPrepare(ctx, prep.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got.Status).To(Equal(model.DeltaPrepareWaiting))
+		Expect(eventReasons()).NotTo(ContainElement(domain.EventReasonFleetRolloutStarted))
+	})
+})

--- a/test/integration/tasks/fleet_rollout_lifecycle_test.go
+++ b/test/integration/tasks/fleet_rollout_lifecycle_test.go
@@ -344,3 +344,105 @@ var _ = Describe("Application lifecycle overlay at render time", func() {
 			"this fleet-wide start is more recent than device-1's own last override (an earlier start), so it takes effect too")
 	})
 })
+
+var _ = Describe("PrepareDeltas holds device-selection member specs", func() {
+	var (
+		log                *logrus.Logger
+		ctx                context.Context
+		orgId              uuid.UUID
+		deviceStore        devicestore.Store
+		fleetStore         fleetstore.Store
+		fleetSvc           fleetservice.Service
+		templateVersionSvc templateversionservice.Service
+		deviceSvc          deviceservice.Service
+		repositorySvc      repositoryservice.Service
+		workerClient       worker_client.WorkerClient
+		cfg                *config.Config
+		dbName             string
+		db                 *gorm.DB
+		ctrl               *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		ctx = testutil.StartSpecTracerForGinkgo(suiteCtx)
+		orgId = store.NullOrgId
+		log = flightlog.InitLogs()
+		var err error
+		cfg, dbName, db, err = testdb.CreateTestDB(ctx, log, "", store.InitDB)
+		Expect(err).NotTo(HaveOccurred())
+		deviceStore = devicestore.NewDeviceStore(db, log.WithField("pkg", "device-store"))
+		fleetStore = fleetstore.NewFleetStore(db, log.WithField("pkg", "fleet-store"))
+		tvStore := templateversionstore.NewTemplateVersionStore(db, log.WithField("pkg", "templateversion-store"))
+		repoStore := repositorystore.NewRepositoryStore(db, log.WithField("pkg", "repository-store"))
+		eventStore := eventstore.NewEventStore(db, log.WithField("pkg", "event-store"))
+		ctrl = gomock.NewController(GinkgoT())
+		mockQueueProducer := queues.NewMockQueueProducer(ctrl)
+		mockQueueProducer.EXPECT().Enqueue(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		workerClient = worker_client.NewWorkerClient(mockQueueProducer, log)
+		kvStoreInst, err := kvstore.NewKVStore(ctx, log, redisHost, redisPort, redisPassword)
+		Expect(err).ToNot(HaveOccurred())
+		eventsSvc := events.NewServiceHandler(eventStore, workerClient, log)
+		fleetSvc = fleetservice.NewServiceHandler(fleetStore, nil, eventsSvc, log)
+		templateVersionSvc = templateversionservice.NewServiceHandler(tvStore, kvStoreInst, eventsSvc, log)
+		deviceSvc = deviceservice.NewDeviceServiceHandler(deviceStore, nil, fleetStore, eventsSvc, kvStoreInst, "", log)
+		repositorySvc = repositoryservice.NewServiceHandler(repoStore, eventsSvc, log)
+	})
+
+	AfterEach(func() {
+		Expect(testdb.DeleteTestDB(ctx, log, cfg, db, dbName)).To(Succeed())
+		ctrl.Finish()
+	})
+
+	It("should not write member specs after template version create", func() {
+		const (
+			fleetName  = "hold-fleet"
+			deviceName = "hold-device"
+			oldImage   = "os"
+			newImage   = "quay.io/acme/os:v2"
+		)
+		selection := &api.RolloutDeviceSelection{}
+		fleet := &api.Fleet{
+			Metadata: api.ObjectMeta{Name: lo.ToPtr(fleetName)},
+			Spec: api.FleetSpec{
+				RolloutPolicy: &api.RolloutPolicy{DeviceSelection: selection},
+				Template: struct {
+					Metadata *api.ObjectMeta `json:"metadata,omitempty"`
+					Spec     api.DeviceSpec  `json:"spec"`
+				}{
+					Spec: api.DeviceSpec{Os: &api.DeviceOsSpec{Image: newImage}},
+				},
+			},
+		}
+		_, err := fleetStore.Create(ctx, orgId, fleet)
+		Expect(err).ToNot(HaveOccurred())
+		testutil.CreateTestDevice(ctx, deviceStore, orgId, deviceName, lo.ToPtr("Fleet/"+fleetName), nil, nil)
+
+		event := api.Event{
+			Reason: api.EventReasonResourceUpdated,
+			InvolvedObject: api.ObjectReference{
+				Kind: api.FleetKind,
+				Name: fleetName,
+			},
+		}
+		logic := tasks.NewFleetValidateLogic(log, fleetSvc, templateVersionSvc, deviceSvc, repositorySvc, nil, orgId, event)
+		logic.WorkerClient = workerClient
+		Expect(logic.CreateNewTemplateVersionIfFleetValid(ctx)).To(Succeed())
+
+		dev, err := deviceStore.Get(ctx, orgId, deviceName)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dev.Spec).ToNot(BeNil())
+		Expect(dev.Spec.Os).ToNot(BeNil())
+		Expect(dev.Spec.Os.Image).To(Equal(oldImage))
+		if dev.Metadata.Annotations != nil {
+			_, hasTV := (*dev.Metadata.Annotations)[api.DeviceAnnotationTemplateVersion]
+			Expect(hasTV).To(BeFalse())
+		}
+
+		gotFleet, err := fleetStore.Get(ctx, orgId, fleetName)
+		Expect(err).ToNot(HaveOccurred())
+		if gotFleet.Metadata.Annotations != nil {
+			_, hasTV := (*gotFleet.Metadata.Annotations)[api.FleetAnnotationTemplateVersion]
+			Expect(hasTV).To(BeFalse())
+		}
+	})
+})

--- a/test/integration/tasks/fleet_validate_test.go
+++ b/test/integration/tasks/fleet_validate_test.go
@@ -182,6 +182,7 @@ var _ = Describe("FleetValidate", func() {
 				},
 			}
 			logic := tasks.NewFleetValidateLogic(log, fleetSvc, templateVersionSvc, deviceSvc, repositorySvc, nil, orgId, event)
+			logic.WorkerClient = workerClient
 
 			gitItem := api.ConfigProviderSpec{}
 			err := gitItem.FromGitConfigProviderSpec(*goodGitConfig)
@@ -241,6 +242,7 @@ var _ = Describe("FleetValidate", func() {
 				},
 			}
 			logic := tasks.NewFleetValidateLogic(log, fleetSvc, templateVersionSvc, deviceSvc, repositorySvc, nil, orgId, event)
+			logic.WorkerClient = workerClient
 
 			gitItem := api.ConfigProviderSpec{}
 			err := gitItem.FromGitConfigProviderSpec(*badGitConfig)
@@ -298,6 +300,7 @@ var _ = Describe("FleetValidate", func() {
 				},
 			}
 			logic := tasks.NewFleetValidateLogic(log, fleetSvc, templateVersionSvc, deviceSvc, repositorySvc, nil, orgId, event)
+			logic.WorkerClient = workerClient
 
 			gitItem := api.ConfigProviderSpec{}
 			err := gitItem.FromGitConfigProviderSpec(*goodGitConfig)
@@ -355,6 +358,7 @@ var _ = Describe("FleetValidate", func() {
 				},
 			}
 			logic := tasks.NewFleetValidateLogic(log, fleetSvc, templateVersionSvc, deviceSvc, repositorySvc, nil, orgId, event)
+			logic.WorkerClient = workerClient
 
 			gitItem := api.ConfigProviderSpec{}
 			err := gitItem.FromGitConfigProviderSpec(*goodGitConfig)


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.

## EDM-5223: Hold rollout behind PrepareDeltas and resume once

**Jira:** https://issues.redhat.com/browse/EDM-5223
**Story type:** [DEV]
**Stacked on:** #3455 (EDM-5222)

### Summary

Fleet template-version create and standalone device spec updates emit `PrepareDeltas` instead of starting rollout or render. When every joined generation pair is terminal, or when `flightctl-periodic` finds a waiting prepare past its deadline, the wait CAS-completes or CAS-fails once, matches live TV or spec generation, then emits `FleetRolloutStarted` or `DeltaGenerationCompleted`. A superceded wait does not emit.

### Changes

- `CreateTemplateVersion` no longer emits `FleetRolloutStarted`. `fleetValidate` creates the TV, skips the TV annotation / `SetOutOfDate`, and emits `PrepareDeltas`.
- Standalone `UpdateDevice` spec changes set delay-render and emit `PrepareDeltas` with no `templateVersion`.
- Last-pair persist calls `CompleteWaitingIfTerminal` → CAS `waiting`→`complete`, then identity match, then annotate / `SetOutOfDate` / resume event.
- New system-wide periodic task `delta-prepare-deadline` (1m): `ListWaitingPastDeadline`, CAS `waiting`→`failed`, same match/emit. Generation rows are not the resume trigger.
- Prepare identity for fleets is the `PrepareDeltas` TV (else latest TV), not `FleetAnnotationTemplateVersion` (that annotation is written on resume).
- `shouldRenderDevice` treats `DeltaGenerationCompleted` as render-now.

### Testing

- **Unit tests:** CAS win/lose, stale TV/RV, supercede, live batched vs immediate strategy, fleetValidate PrepareDeltas, standalone delay, deadline poll, identity keyed to event TV
- **Integration tests:** last-pair emit, past-deadline fail + emit with `in_progress` generation unchanged, null deadline no emit, device-selection fleet does not write member specs on TV create
- **Validation:** `make lint`, `make unit-test`, `make integration-test` passed

### Acceptance Criteria

- [ ] AC-1: `fleetValidate` still creates the TemplateVersion, then emits `PrepareDeltas` instead of starting fleet rollout. `UpdateDevice` writes `Device.Spec`, emits `PrepareDeltas` (no `templateVersion`), and delays `RenderDevice`.
- [ ] AC-2: Last-pair CAS `waiting`→`complete` and emit only if latest TV or device spec RV still matches. Only one resume wins.
- [ ] AC-3: Periodic lists waiting prepares with past deadline, CAS `waiting`→`failed`, same match. Omit `maxWaitForDelta`: no periodic deadline. Sweeping a `delta_generations` row does not resume.
- [ ] AC-4: Fleet resume sets `FleetAnnotationTemplateVersion`, `SetOutOfDate`, emits `FleetRolloutStarted` from the live Fleet strategy, clears preparing status. Device resume: `DeltaGenerationCompleted` → render if RV matches.
- [ ] AC-5: Supercede does not emit. Stale TV/RV does not emit.
- [ ] AC-6: Deadline `failed` still emits. In-flight generation jobs keep running under `deltaGenerationTimeout`.
