### PR TITLE
EDM-5224: RenderDevice sets OS deltaImage and Updated.Size

### DIFF
--- a/internal/service/device/handler.go
+++ b/internal/service/device/handler.go
@@ -758,7 +758,7 @@ func (h *DeviceServiceHandler) UpdateDeviceAnnotations(ctx context.Context, orgI
 	return common.StoreErrorToApiStatus(err, false, domain.DeviceKind, &name)
 }
 
-func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) domain.Status {
+func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, osHints *RenderedOSHints) domain.Status {
 	specValid := domain.Condition{
 		Type:   domain.ConditionTypeDeviceSpecValid,
 		Status: domain.ConditionStatusTrue,
@@ -778,7 +778,7 @@ func (h *DeviceServiceHandler) UpdateRenderedDevice(ctx context.Context, orgId u
 		if m.Device.Status != nil {
 			oldConditions = append([]domain.Condition(nil), m.Device.Status.Conditions...)
 		}
-		version, err := applyRenderedUpdate(m, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate)
+		version, err := applyRenderedUpdate(m, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate, osHints)
 		if err != nil {
 			return err
 		}

--- a/internal/service/device/handler_test.go
+++ b/internal/service/device/handler_test.go
@@ -850,7 +850,7 @@ func TestUpdateRenderedDevice(t *testing.T) {
 		Status: lo.ToPtr(domain.NewDeviceStatus()),
 	}, nil)
 	require.NoError(t, err)
-	status := svc.UpdateRenderedDevice(ctx, orgId, "foo", "config", "apps", "hash", "", nil, false)
+	status := svc.UpdateRenderedDevice(ctx, orgId, "foo", "config", "apps", "hash", "", nil, false, nil)
 	require.Equal(t, int32(http.StatusOK), status.Code)
 }
 

--- a/internal/service/device/mock.go
+++ b/internal/service/device/mock.go
@@ -552,17 +552,17 @@ func (mr *MockServiceMockRecorder) UpdateDeviceAnnotations(ctx, orgId, name, ann
 }
 
 // UpdateRenderedDevice mocks base method.
-func (m *MockService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) domain.Status {
+func (m *MockService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, osHints *RenderedOSHints) domain.Status {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRenderedDevice", ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate)
+	ret := m.ctrl.Call(m, "UpdateRenderedDevice", ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate, osHints)
 	ret0, _ := ret[0].(domain.Status)
 	return ret0
 }
 
 // UpdateRenderedDevice indicates an expected call of UpdateRenderedDevice.
-func (mr *MockServiceMockRecorder) UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate any) *gomock.Call {
+func (mr *MockServiceMockRecorder) UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate, osHints any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRenderedDevice", reflect.TypeOf((*MockService)(nil).UpdateRenderedDevice), ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRenderedDevice", reflect.TypeOf((*MockService)(nil).UpdateRenderedDevice), ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate, osHints)
 }
 
 // UpdateServerSideDeviceStatus mocks base method.

--- a/internal/service/device/rendered.go
+++ b/internal/service/device/rendered.go
@@ -17,6 +17,7 @@ func applyRenderedUpdate(
 	renderedConfig, renderedApplications, specHash, osImage string,
 	configFingerprints []domain.DependencySyncConfigRefStatus,
 	forceUpdate bool,
+	osHints *RenderedOSHints,
 ) (renderedVersion string, err error) {
 	device := m.Device
 	ann := util.EnsureMap(lo.FromPtr(device.Metadata.Annotations))
@@ -55,6 +56,12 @@ func applyRenderedUpdate(
 		Config:       renderedConfig,
 		Applications: renderedApplications,
 		OsImage:      osImage,
+	}
+	if osHints != nil {
+		m.Rendered.OsDeltaImage = osHints.DeltaImage
+		if osHints.UpdatedSize != nil {
+			device.Status.Updated.Size = osHints.UpdatedSize
+		}
 	}
 	return next, nil
 }

--- a/internal/service/device/service.go
+++ b/internal/service/device/service.go
@@ -43,7 +43,7 @@ type Service interface {
 	StopDeviceApplication(ctx context.Context, orgId uuid.UUID, name string, appName string) (*domain.Device, domain.Status)
 	StartDeviceApplication(ctx context.Context, orgId uuid.UUID, name string, appName string) (*domain.Device, domain.Status)
 	RestartDeviceApplication(ctx context.Context, orgId uuid.UUID, name string, appName string) (*domain.Device, domain.Status)
-	UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) domain.Status
+	UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name, renderedConfig, renderedApplications, specHash, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, osHints *RenderedOSHints) domain.Status
 	SetDeviceServiceConditions(ctx context.Context, orgId uuid.UUID, name string, conditions []domain.Condition) domain.Status
 	OverwriteDeviceRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string, repositoryNames ...string) domain.Status
 	GetDeviceRepositoryRefs(ctx context.Context, orgId uuid.UUID, name string) (*domain.RepositoryList, domain.Status)
@@ -59,4 +59,11 @@ type Service interface {
 	ForceUpdateServerSideDeviceStatus(ctx context.Context, orgId uuid.UUID, name string) error
 	ListConnectivityChangedDevices(ctx context.Context, orgId uuid.UUID, params domain.ListDevicesParams, cutoffTime time.Time) (*domain.DeviceList, domain.Status)
 	ListLabels(ctx context.Context, orgId uuid.UUID, params domain.ListLabelsParams) (*domain.LabelList, domain.Status)
+}
+
+// RenderedOSHints is applied when persisting a rendered spec: optional OS
+// deltaImage on the rendered OS spec and status.updated.size.
+type RenderedOSHints struct {
+	DeltaImage  *string
+	UpdatedSize *string
 }

--- a/internal/service/device/traced.gen.go
+++ b/internal/service/device/traced.gen.go
@@ -331,10 +331,10 @@ func (_d *TracedDeviceService) UpdateDeviceAnnotations(ctx context.Context, orgI
 	return s1
 }
 
-func (_d *TracedDeviceService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, renderedConfig string, renderedApplications string, specHash string, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool) (s1 domain.Status) {
+func (_d *TracedDeviceService) UpdateRenderedDevice(ctx context.Context, orgId uuid.UUID, name string, renderedConfig string, renderedApplications string, specHash string, osImage string, configFingerprints []domain.DependencySyncConfigRefStatus, forceUpdate bool, osHints *RenderedOSHints) (s1 domain.Status) {
 	ctx, span := startSpan(ctx, "UpdateRenderedDevice")
 
-	s1 = _d.inner.UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate)
+	s1 = _d.inner.UpdateRenderedDevice(ctx, orgId, name, renderedConfig, renderedApplications, specHash, osImage, configFingerprints, forceUpdate, osHints)
 	endSpan(span, s1)
 	return s1
 }

--- a/internal/store/device/store.go
+++ b/internal/store/device/store.go
@@ -126,6 +126,14 @@ type DeviceRendered struct {
 	Config       string
 	Applications string
 	OsImage      string
+	OsDeltaImage *string
+}
+
+func renderedOsSpec(rendered *DeviceRendered) domain.DeviceOsSpec {
+	if rendered == nil {
+		return domain.DeviceOsSpec{}
+	}
+	return domain.DeviceOsSpec{Image: rendered.OsImage, DeltaImage: rendered.OsDeltaImage}
 }
 
 // DeviceMutation is the unit apply mutates. Handlers decide all field changes.
@@ -661,7 +669,7 @@ func (s *DeviceStore) Create(ctx context.Context, orgId uuid.UUID, device *domai
 			apps = "[]"
 		}
 		deviceModel.RenderedApplications = model.MakeJSONField(json.RawMessage(apps))
-		deviceModel.RenderedOs = model.MakeJSONField(domain.DeviceOsSpec{Image: rendered.OsImage})
+		deviceModel.RenderedOs = model.MakeJSONField(renderedOsSpec(rendered))
 		deviceModel.RenderTimestamp = time.Now()
 	}
 
@@ -720,7 +728,7 @@ func (s *DeviceStore) Update(ctx context.Context, orgId uuid.UUID, before, devic
 		}
 		updates["rendered_config"] = &cfg
 		updates["rendered_applications"] = &apps
-		updates["rendered_os"] = model.MakeJSONField(domain.DeviceOsSpec{Image: rendered.OsImage})
+		updates["rendered_os"] = model.MakeJSONField(renderedOsSpec(rendered))
 		updates["render_timestamp"] = time.Now()
 	}
 

--- a/internal/tasks/consumer.go
+++ b/internal/tasks/consumer.go
@@ -45,6 +45,7 @@ type TaskConsumer struct {
 	EncryptionMigrator *EncryptionMigrator
 	QueuePublisher     queues.QueueProducer
 	WorkerClient       worker_client.WorkerClient
+	DeltaStore         generationLookup
 }
 
 func (d TaskConsumer) dispatch() queues.ConsumeHandler {
@@ -133,7 +134,7 @@ func (d TaskConsumer) dispatch() queues.ConsumeHandler {
 		if shouldRenderDevice(ctx, eventWithOrgId.Event, log) {
 			taskName = "deviceRender"
 			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
-				return deviceRender(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.DeviceSvc, d.RepositorySvc, d.CatalogSvc, d.K8sClient, d.KVStore, d.Cfg, log)
+				return deviceRender(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.DeviceSvc, d.RepositorySvc, d.CatalogSvc, d.K8sClient, d.KVStore, d.DeltaStore, d.Cfg, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}

--- a/internal/tasks/consumer.go
+++ b/internal/tasks/consumer.go
@@ -46,6 +46,7 @@ type TaskConsumer struct {
 	QueuePublisher     queues.QueueProducer
 	WorkerClient       worker_client.WorkerClient
 	DeltaStore         generationLookup
+	Preparing          preparingClearer
 }
 
 func (d TaskConsumer) dispatch() queues.ConsumeHandler {
@@ -134,7 +135,7 @@ func (d TaskConsumer) dispatch() queues.ConsumeHandler {
 		if shouldRenderDevice(ctx, eventWithOrgId.Event, log) {
 			taskName = "deviceRender"
 			err = runTaskWithMetrics(taskName, d.WorkerMetrics, func() error {
-				return deviceRender(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.DeviceSvc, d.RepositorySvc, d.CatalogSvc, d.K8sClient, d.KVStore, d.DeltaStore, d.Cfg, log)
+				return deviceRender(ctx, eventWithOrgId.OrgId, eventWithOrgId.Event, d.DeviceSvc, d.RepositorySvc, d.CatalogSvc, d.K8sClient, d.KVStore, d.DeltaStore, d.Preparing, d.Cfg, log)
 			})
 			errorMessages = appendErrorMessage(errorMessages, taskName, err)
 		}

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -50,9 +50,10 @@ import (
 // This design ensures the task can be retried safely, detects mid-write inconsistencies,
 // and avoids unnecessary reprocessing when the output is already up to date.
 
-func deviceRender(ctx context.Context, orgId uuid.UUID, event domain.Event, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, deltaStore generationLookup, cfg *config.Config, log logrus.FieldLogger) error {
+func deviceRender(ctx context.Context, orgId uuid.UUID, event domain.Event, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, deltaStore generationLookup, preparing preparingClearer, cfg *config.Config, log logrus.FieldLogger) error {
 	logic := NewDeviceRenderLogic(log, deviceSvc, repositorySvc, catalogSvc, k8sClient, kvStore, cfg, orgId, event)
 	logic.deltaLookup = deltaStore
+	logic.preparing = preparing
 	if event.InvolvedObject.Kind == domain.DeviceKind {
 		err := logic.RenderDevice(ctx)
 		if err != nil {
@@ -84,6 +85,7 @@ type DeviceRenderLogic struct {
 	vmRenderOptions VmRenderOptions
 	deltaLookup     generationLookup
 	osManifestSize  func(context.Context, string) (*int64, error)
+	preparing       preparingClearer
 }
 
 func NewDeviceRenderLogic(log logrus.FieldLogger, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, orgId uuid.UUID, event domain.Event) DeviceRenderLogic {
@@ -254,7 +256,24 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 	if err := common.ApiStatusToErr(status); err != nil {
 		return t.setErrorStatus(ctx, err)
 	}
+	t.clearStandalonePreparing(ctx, device)
 	return nil
+}
+
+type preparingClearer interface {
+	Clear(ctx context.Context, orgId uuid.UUID, kind, name string) error
+}
+
+func (t *DeviceRenderLogic) clearStandalonePreparing(ctx context.Context, device *domain.Device) {
+	if t.preparing == nil || device == nil {
+		return
+	}
+	if device.Metadata.Owner != nil && *device.Metadata.Owner != "" {
+		return
+	}
+	if err := t.preparing.Clear(ctx, t.orgId, domain.DeviceKind, t.event.InvolvedObject.Name); err != nil {
+		t.log.Warnf("failed clearing leftover DeviceDeltaPreparing for device %s/%s: %v", t.orgId, t.event.InvolvedObject.Name, err)
+	}
 }
 
 var errIgnitionConversion = errors.New("failed converting ignition config to rendered config")

--- a/internal/tasks/device_render.go
+++ b/internal/tasks/device_render.go
@@ -50,8 +50,9 @@ import (
 // This design ensures the task can be retried safely, detects mid-write inconsistencies,
 // and avoids unnecessary reprocessing when the output is already up to date.
 
-func deviceRender(ctx context.Context, orgId uuid.UUID, event domain.Event, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, log logrus.FieldLogger) error {
+func deviceRender(ctx context.Context, orgId uuid.UUID, event domain.Event, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, deltaStore generationLookup, cfg *config.Config, log logrus.FieldLogger) error {
 	logic := NewDeviceRenderLogic(log, deviceSvc, repositorySvc, catalogSvc, k8sClient, kvStore, cfg, orgId, event)
+	logic.deltaLookup = deltaStore
 	if event.InvolvedObject.Kind == domain.DeviceKind {
 		err := logic.RenderDevice(ctx)
 		if err != nil {
@@ -81,6 +82,8 @@ type DeviceRenderLogic struct {
 	applications    *[]domain.ApplicationProviderSpec
 	vmConverter     VmConverterFn
 	vmRenderOptions VmRenderOptions
+	deltaLookup     generationLookup
+	osManifestSize  func(context.Context, string) (*int64, error)
 }
 
 func NewDeviceRenderLogic(log logrus.FieldLogger, deviceSvc deviceservice.Service, repositorySvc repositoryservice.Service, catalogSvc catalogservice.Service, k8sClient k8sclient.K8SClient, kvStore kvstore.KVStore, cfg *config.Config, orgId uuid.UUID, event domain.Event) DeviceRenderLogic {
@@ -247,7 +250,7 @@ func (t *DeviceRenderLogic) RenderDevice(ctx context.Context) error {
 		syncRefs = append(syncRefs, ref)
 	}
 
-	status = t.deviceSvc.UpdateRenderedDevice(ctx, t.orgId, t.event.InvolvedObject.Name, string(rendered.Config), string(rendered.Applications), specHash, rendered.OsImage, syncRefs, bypassHashCheck)
+	status = t.deviceSvc.UpdateRenderedDevice(ctx, t.orgId, t.event.InvolvedObject.Name, string(rendered.Config), string(rendered.Applications), specHash, rendered.OsImage, syncRefs, bypassHashCheck, t.resolveOSDeltaHint(ctx, device, rendered))
 	if err := common.ApiStatusToErr(status); err != nil {
 		return t.setErrorStatus(ctx, err)
 	}

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -1502,3 +1502,127 @@ func TestRenderDevice_SucceededGenerationSetsDeltaImageAndSize(t *testing.T) {
 
 	require.NoError(t, logic.RenderDevice(context.Background()))
 }
+
+type recordingPreparingClearer struct {
+	mu    sync.Mutex
+	calls []struct {
+		orgId uuid.UUID
+		kind  string
+		name  string
+	}
+	err error
+}
+
+func (r *recordingPreparingClearer) Clear(_ context.Context, orgId uuid.UUID, kind, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, struct {
+		orgId uuid.UUID
+		kind  string
+		name  string
+	}{orgId: orgId, kind: kind, name: name})
+	return r.err
+}
+
+func TestRenderDevice_StandaloneClearsDeviceDeltaPreparing(t *testing.T) {
+	const deviceName = "standalone-clear-preparing"
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+		Spec: &domain.DeviceSpec{
+			Os: &domain.DeviceOsSpec{Image: "quay.io/acme/os:latest"},
+		},
+	}
+
+	mockDeviceSvc := deviceservice.NewMockService(ctrl)
+	mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+	mockDeviceSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateRenderedDevice(
+		gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(statusOK)
+
+	clearer := &recordingPreparingClearer{}
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+	logic.preparing = clearer
+
+	require.NoError(t, logic.RenderDevice(context.Background()))
+	require.Len(t, clearer.calls, 1)
+	assert.Equal(t, orgId, clearer.calls[0].orgId)
+	assert.Equal(t, domain.DeviceKind, clearer.calls[0].kind)
+	assert.Equal(t, deviceName, clearer.calls[0].name)
+}
+
+func TestRenderDevice_FleetOwnedDoesNotClearDeviceDeltaPreparing(t *testing.T) {
+	const (
+		deviceName      = "fleet-owned-no-clear"
+		fleet           = "hint-fleet"
+		templateVersion = "tv-1"
+		osImage         = "quay.io/acme/os:latest"
+	)
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ownerStr := fmt.Sprintf("Fleet/%s", fleet)
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{
+			Name:  lo.ToPtr(deviceName),
+			Owner: &ownerStr,
+			Annotations: &map[string]string{
+				domain.DeviceAnnotationTemplateVersion: templateVersion,
+			},
+		},
+		Spec: &domain.DeviceSpec{
+			Os: &domain.DeviceOsSpec{Image: osImage},
+		},
+	}
+
+	mockDeviceSvc := deviceservice.NewMockService(ctrl)
+	mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+	mockDeviceSvc.EXPECT().UpdateRenderedDevice(
+		gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), osImage, gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(statusOK)
+
+	clearer := &recordingPreparingClearer{}
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+	logic.preparing = clearer
+
+	require.NoError(t, logic.RenderDevice(context.Background()))
+	assert.Empty(t, clearer.calls)
+}
+
+func TestRenderDevice_DoesNotClearDeviceDeltaPreparingWhenPersistFails(t *testing.T) {
+	const deviceName = "standalone-persist-fail"
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+		Spec: &domain.DeviceSpec{
+			Os: &domain.DeviceOsSpec{Image: "quay.io/acme/os:latest"},
+		},
+	}
+
+	mockDeviceSvc := deviceservice.NewMockService(ctrl)
+	mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+	mockDeviceSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateRenderedDevice(
+		gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(domain.Status{Code: http.StatusInternalServerError, Message: "persist failed"})
+	mockDeviceSvc.EXPECT().SetDeviceServiceConditions(gomock.Any(), orgId, deviceName, gomock.Any()).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateServerSideDeviceStatus(gomock.Any(), orgId, deviceName).Return(nil)
+
+	clearer := &recordingPreparingClearer{}
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+	logic.preparing = clearer
+
+	require.Error(t, logic.RenderDevice(context.Background()))
+	assert.Empty(t, clearer.calls)
+}

--- a/internal/tasks/device_render_test.go
+++ b/internal/tasks/device_render_test.go
@@ -22,6 +22,7 @@ import (
 	catalogservice "github.com/flightctl/flightctl/internal/service/catalog"
 	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	repositoryservice "github.com/flightctl/flightctl/internal/service/repository"
+	"github.com/flightctl/flightctl/internal/store/model"
 	"github.com/flightctl/flightctl/pkg/k8sclient"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -1001,7 +1002,7 @@ func TestRenderDevice_CatalogItemRef_ResolvesOsImage(t *testing.T) {
 	mockCatalogSvc.EXPECT().GetCatalogItem(gomock.Any(), orgId, catalogName, itemName).Return(catalogItem, statusOK)
 
 	expectedOsImage := artifactUri + ":" + containerRef
-	mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), expectedOsImage, gomock.Any(), gomock.Any()).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), expectedOsImage, gomock.Any(), gomock.Any(), gomock.Any()).Return(statusOK)
 
 	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
 	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, mockCatalogSvc, nil, newTestKVStore(), &config.Config{}, orgId, event)
@@ -1036,7 +1037,7 @@ func TestRenderDevice_NoCatalogItemRef_PassesPlainOsImage(t *testing.T) {
 	mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
 	mockDeviceSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
 
-	mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), plainImage, gomock.Any(), gomock.Any()).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), plainImage, gomock.Any(), gomock.Any(), gomock.Any()).Return(statusOK)
 
 	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
 	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
@@ -1075,7 +1076,7 @@ func TestRenderDevice_CatalogRefAndPlainImage_ResolveIndependently(t *testing.T)
 	mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(catalogDevice, statusOK)
 	mockDeviceSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
 	mockCatalogSvc.EXPECT().GetCatalogItem(gomock.Any(), orgId, catalogName, itemName).Return(catalogItem, statusOK)
-	mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), expectedCatalogOsImage, gomock.Any(), gomock.Any()).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), expectedCatalogOsImage, gomock.Any(), gomock.Any(), gomock.Any()).Return(statusOK)
 
 	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
 	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, mockCatalogSvc, nil, newTestKVStore(), &config.Config{}, orgId, event)
@@ -1094,7 +1095,7 @@ func TestRenderDevice_CatalogRefAndPlainImage_ResolveIndependently(t *testing.T)
 	gomock.InOrder(
 		mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(plainDevice, statusOK),
 		mockDeviceSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK),
-		mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), plainImage, gomock.Any(), gomock.Any()).Return(statusOK),
+		mockDeviceSvc.EXPECT().UpdateRenderedDevice(gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), plainImage, gomock.Any(), gomock.Any(), gomock.Any()).Return(statusOK),
 	)
 
 	event2 := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
@@ -1453,4 +1454,51 @@ func TestRenderSpec_WhenHTTPConfigItShouldIncludeFetchedBodyWithoutPersisting(t 
 	require.NoError(t, err)
 	assert.Equal(t, "quay.io/os/base:latest", rendered.OsImage)
 	assert.Contains(t, string(rendered.Config), base64.StdEncoding.EncodeToString([]byte(body)))
+}
+
+func TestRenderDevice_SucceededGenerationSetsDeltaImageAndSize(t *testing.T) {
+	const deviceName = "device-delta-hint"
+	src := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	tgt := "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	osImage := "quay.io/acme/os@" + tgt
+	deltaRef := "quay.io/acme/os@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	size := int64(47185920)
+
+	orgId := uuid.New()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	device := &domain.Device{
+		Metadata: domain.ObjectMeta{Name: lo.ToPtr(deviceName)},
+		Spec: &domain.DeviceSpec{
+			Os: &domain.DeviceOsSpec{Image: osImage},
+		},
+		Status: &domain.DeviceStatus{
+			Os: domain.DeviceOsStatus{ImageDigest: src},
+		},
+	}
+
+	mockDeviceSvc := deviceservice.NewMockService(ctrl)
+	mockDeviceSvc.EXPECT().GetDevice(gomock.Any(), orgId, deviceName).Return(device, statusOK)
+	mockDeviceSvc.EXPECT().OverwriteDeviceRepositoryRefs(gomock.Any(), orgId, deviceName).Return(statusOK)
+	mockDeviceSvc.EXPECT().UpdateRenderedDevice(
+		gomock.Any(), orgId, deviceName, gomock.Any(), gomock.Any(), gomock.Any(), osImage, gomock.Any(), gomock.Any(), gomock.Any(),
+	).DoAndReturn(func(_ context.Context, _ uuid.UUID, _ string, _, _, _, _ string, _ []domain.DependencySyncConfigRefStatus, _ bool, hints *deviceservice.RenderedOSHints) domain.Status {
+		require.NotNil(t, hints)
+		require.Equal(t, deltaRef, lo.FromPtr(hints.DeltaImage))
+		require.Equal(t, "45 MiB", lo.FromPtr(hints.UpdatedSize))
+		return statusOK
+	})
+
+	event := createTestEvent(domain.DeviceKind, domain.EventReasonResourceUpdated, deviceName)
+	logic := NewDeviceRenderLogic(logrus.New(), mockDeviceSvc, nil, nil, nil, newTestKVStore(), &config.Config{}, orgId, event)
+	logic.deltaLookup = &stubGenerationLookup{
+		gen: &model.DeltaGeneration{
+			Status:    model.DeltaGenerationSucceeded,
+			DeltaRef:  &deltaRef,
+			SizeBytes: &size,
+		},
+	}
+
+	require.NoError(t, logic.RenderDevice(context.Background()))
 }

--- a/internal/tasks/os_delta_hint.go
+++ b/internal/tasks/os_delta_hint.go
@@ -53,6 +53,11 @@ func FormatIECBytes(n int64) string {
 	return fmt.Sprintf("%d %s", rounded, units[unit])
 }
 
+func (t DeviceRenderLogic) WithDeltaLookup(lookup delta.Store) DeviceRenderLogic {
+	t.deltaLookup = lookup
+	return t
+}
+
 func ImageRepositoryFromRef(imageRef string) (string, error) {
 	named, err := reference.ParseNormalizedNamed(imageRef)
 	if err != nil {

--- a/internal/tasks/os_delta_hint.go
+++ b/internal/tasks/os_delta_hint.go
@@ -1,0 +1,93 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/kvstore"
+	"github.com/flightctl/flightctl/internal/store/delta"
+	"github.com/flightctl/flightctl/internal/store/model"
+)
+
+const generationMemoTTL = 15 * time.Minute
+
+type generationLookup interface {
+	GetGeneration(ctx context.Context, key delta.GenerationKey) (*model.DeltaGeneration, error)
+}
+
+type generationMemo struct {
+	Missing   bool    `json:"missing,omitempty"`
+	Status    string  `json:"status,omitempty"`
+	DeltaRef  *string `json:"deltaRef,omitempty"`
+	SizeBytes *int64  `json:"sizeBytes,omitempty"`
+}
+
+func generationMemoKey(key delta.GenerationKey) string {
+	return fmt.Sprintf("deltaHint/%s/%s/%s/%s", key.OrgID, key.ImageRepository, key.SourceDigest, key.TargetDigest)
+}
+
+func lookupCachedGeneration(ctx context.Context, kv kvstore.KVStore, store generationLookup, key delta.GenerationKey) (*model.DeltaGeneration, error) {
+	if kv != nil {
+		raw, err := kv.Get(ctx, generationMemoKey(key))
+		if err == nil && len(raw) > 0 {
+			var memo generationMemo
+			if err := json.Unmarshal(raw, &memo); err == nil {
+				return generationFromMemo(key, memo), nil
+			}
+		}
+	}
+
+	if store == nil {
+		return nil, nil
+	}
+	gen, err := store.GetGeneration(ctx, key)
+	if err != nil {
+		if errors.Is(err, flterrors.ErrResourceNotFound) {
+			_ = writeGenerationMemo(ctx, kv, key, generationMemo{Missing: true})
+			return nil, nil
+		}
+		return nil, err
+	}
+	if gen != nil {
+		_ = writeGenerationMemo(ctx, kv, key, generationMemo{
+			Status:    gen.Status,
+			DeltaRef:  gen.DeltaRef,
+			SizeBytes: gen.SizeBytes,
+		})
+	}
+	return gen, nil
+}
+
+func generationFromMemo(key delta.GenerationKey, memo generationMemo) *model.DeltaGeneration {
+	if memo.Missing {
+		return nil
+	}
+	return &model.DeltaGeneration{
+		OrgID:           key.OrgID,
+		ImageRepository: key.ImageRepository,
+		SourceDigest:    key.SourceDigest,
+		TargetDigest:    key.TargetDigest,
+		Status:          memo.Status,
+		DeltaRef:        memo.DeltaRef,
+		SizeBytes:       memo.SizeBytes,
+	}
+}
+
+func writeGenerationMemo(ctx context.Context, kv kvstore.KVStore, key delta.GenerationKey, memo generationMemo) error {
+	if kv == nil {
+		return nil
+	}
+	raw, err := json.Marshal(memo)
+	if err != nil {
+		return err
+	}
+	cacheKey := generationMemoKey(key)
+	if _, err := kv.SetNX(ctx, cacheKey, raw); err != nil {
+		return err
+	}
+	return kv.SetExpire(ctx, cacheKey, generationMemoTTL)
+}

--- a/internal/tasks/os_delta_hint.go
+++ b/internal/tasks/os_delta_hint.go
@@ -7,10 +7,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containers/image/v5/docker/reference"
+	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/flterrors"
 	"github.com/flightctl/flightctl/internal/kvstore"
+	deviceservice "github.com/flightctl/flightctl/internal/service/device"
 	"github.com/flightctl/flightctl/internal/store/delta"
 	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/samber/lo"
 )
 
 const generationMemoTTL = 15 * time.Minute
@@ -47,6 +51,91 @@ func FormatIECBytes(n int64) string {
 		rounded = 1
 	}
 	return fmt.Sprintf("%d %s", rounded, units[unit])
+}
+
+func ImageRepositoryFromRef(imageRef string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return "", err
+	}
+	return named.Name(), nil
+}
+
+func digestFromImageRef(imageRef string) string {
+	named, err := reference.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return ""
+	}
+	digested, ok := named.(reference.Digested)
+	if !ok {
+		return ""
+	}
+	return digested.Digest().String()
+}
+
+func hintFromGeneration(gen *model.DeltaGeneration, fallbackSize *int64) (deltaImage *string, sizeIEC *string) {
+	var sizeBytes *int64
+	if gen != nil && gen.SizeBytes != nil {
+		sizeBytes = gen.SizeBytes
+	} else {
+		sizeBytes = fallbackSize
+	}
+	if sizeBytes != nil {
+		sizeIEC = lo.ToPtr(FormatIECBytes(*sizeBytes))
+	}
+	if gen != nil && gen.Status == model.DeltaGenerationSucceeded && gen.DeltaRef != nil && *gen.DeltaRef != "" {
+		deltaImage = gen.DeltaRef
+	}
+	return deltaImage, sizeIEC
+}
+
+func (t *DeviceRenderLogic) resolveOSDeltaHint(ctx context.Context, device *domain.Device, rendered RenderedSpec) *deviceservice.RenderedOSHints {
+	if rendered.OsImage == "" {
+		return nil
+	}
+	var fallback *int64
+	if t.osManifestSize != nil {
+		fallback, _ = t.osManifestSize(ctx, rendered.OsImage)
+	}
+	repo, err := ImageRepositoryFromRef(rendered.OsImage)
+	if err != nil || t.deltaLookup == nil {
+		_, size := hintFromGeneration(nil, fallback)
+		if size == nil {
+			return nil
+		}
+		return &deviceservice.RenderedOSHints{UpdatedSize: size}
+	}
+	src := ""
+	if device != nil && device.Status != nil {
+		src = device.Status.Os.ImageDigest
+	}
+	tgt := digestFromImageRef(rendered.OsImage)
+	if src == "" || tgt == "" {
+		_, size := hintFromGeneration(nil, fallback)
+		if size == nil {
+			return nil
+		}
+		return &deviceservice.RenderedOSHints{UpdatedSize: size}
+	}
+	gen, err := lookupCachedGeneration(ctx, t.kvStore, t.deltaLookup, delta.GenerationKey{
+		OrgID:           t.orgId,
+		ImageRepository: repo,
+		SourceDigest:    src,
+		TargetDigest:    tgt,
+	})
+	if err != nil {
+		t.log.Warnf("delta generation lookup failed for device %s/%s: %v", t.orgId, t.event.InvolvedObject.Name, err)
+		_, size := hintFromGeneration(nil, fallback)
+		if size == nil {
+			return nil
+		}
+		return &deviceservice.RenderedOSHints{UpdatedSize: size}
+	}
+	img, size := hintFromGeneration(gen, fallback)
+	if img == nil && size == nil {
+		return nil
+	}
+	return &deviceservice.RenderedOSHints{DeltaImage: img, UpdatedSize: size}
 }
 
 func generationMemoKey(key delta.GenerationKey) string {

--- a/internal/tasks/os_delta_hint.go
+++ b/internal/tasks/os_delta_hint.go
@@ -26,6 +26,29 @@ type generationMemo struct {
 	SizeBytes *int64  `json:"sizeBytes,omitempty"`
 }
 
+func FormatIECBytes(n int64) string {
+	if n <= 0 {
+		return "0 KiB"
+	}
+	units := []string{"KiB", "MiB", "GiB", "TiB"}
+	val := float64(n) / 1024
+	unit := 0
+	for unit < len(units)-1 && val >= 1024 {
+		val /= 1024
+		unit++
+	}
+	rounded := int64(val + 0.5)
+	if rounded == 0 && unit > 0 {
+		val *= 1024
+		unit--
+		rounded = int64(val + 0.5)
+	}
+	if rounded == 0 {
+		rounded = 1
+	}
+	return fmt.Sprintf("%d %s", rounded, units[unit])
+}
+
 func generationMemoKey(key delta.GenerationKey) string {
 	return fmt.Sprintf("deltaHint/%s/%s/%s/%s", key.OrgID, key.ImageRepository, key.SourceDigest, key.TargetDigest)
 }

--- a/internal/tasks/os_delta_hint_test.go
+++ b/internal/tasks/os_delta_hint_test.go
@@ -1,0 +1,110 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/flterrors"
+	"github.com/flightctl/flightctl/internal/store/delta"
+	"github.com/flightctl/flightctl/internal/store/model"
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+type stubGenerationLookup struct {
+	mu    sync.Mutex
+	calls int
+	gen   *model.DeltaGeneration
+	err   error
+}
+
+func (s *stubGenerationLookup) GetGeneration(_ context.Context, _ delta.GenerationKey) (*model.DeltaGeneration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.gen, nil
+}
+
+func (s *stubGenerationLookup) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func testGenerationKey() delta.GenerationKey {
+	return delta.GenerationKey{
+		OrgID:           uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		ImageRepository: "quay.io/acme/os",
+		SourceDigest:    "sha256:aaa",
+		TargetDigest:    "sha256:bbb",
+	}
+}
+
+func TestLookupCachedGeneration(t *testing.T) {
+	ctx := context.Background()
+	key := testGenerationKey()
+	row := &model.DeltaGeneration{
+		OrgID:           key.OrgID,
+		ImageRepository: key.ImageRepository,
+		SourceDigest:    key.SourceDigest,
+		TargetDigest:    key.TargetDigest,
+		Status:          model.DeltaGenerationSucceeded,
+		DeltaRef:        lo.ToPtr("quay.io/acme/os@sha256:delta"),
+		SizeBytes:       lo.ToPtr(int64(47185920)),
+	}
+
+	t.Run("When the cache is empty it should load from the store and return the row", func(t *testing.T) {
+		kv := newTestKVStore()
+		store := &stubGenerationLookup{gen: row}
+
+		got, err := lookupCachedGeneration(ctx, kv, store, key)
+		require.NoError(t, err)
+		require.Equal(t, row, got)
+		require.Equal(t, 1, store.callCount())
+		require.True(t, kv.has(generationMemoKey(key)))
+	})
+
+	t.Run("When the cache is populated it should not query the store again", func(t *testing.T) {
+		kv := newTestKVStore()
+		store := &stubGenerationLookup{gen: row}
+
+		_, err := lookupCachedGeneration(ctx, kv, store, key)
+		require.NoError(t, err)
+		got, err := lookupCachedGeneration(ctx, kv, store, key)
+		require.NoError(t, err)
+		require.Equal(t, row.Status, got.Status)
+		require.Equal(t, row.DeltaRef, got.DeltaRef)
+		require.Equal(t, row.SizeBytes, got.SizeBytes)
+		require.Equal(t, 1, store.callCount())
+	})
+
+	t.Run("When the store has no row it should cache the miss", func(t *testing.T) {
+		kv := newTestKVStore()
+		store := &stubGenerationLookup{err: flterrors.ErrResourceNotFound}
+
+		got, err := lookupCachedGeneration(ctx, kv, store, key)
+		require.NoError(t, err)
+		require.Nil(t, got)
+		got, err = lookupCachedGeneration(ctx, kv, store, key)
+		require.NoError(t, err)
+		require.Nil(t, got)
+		require.Equal(t, 1, store.callCount())
+	})
+
+	t.Run("When the store fails it should not cache the error", func(t *testing.T) {
+		kv := newTestKVStore()
+		store := &stubGenerationLookup{err: errors.New("db down")}
+
+		_, err := lookupCachedGeneration(ctx, kv, store, key)
+		require.Error(t, err)
+		_, err = lookupCachedGeneration(ctx, kv, store, key)
+		require.Error(t, err)
+		require.Equal(t, 2, store.callCount())
+	})
+}

--- a/internal/tasks/os_delta_hint_test.go
+++ b/internal/tasks/os_delta_hint_test.go
@@ -46,6 +46,26 @@ func testGenerationKey() delta.GenerationKey {
 	}
 }
 
+func TestFormatIECBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int64
+		want string
+	}{
+		{name: "When the size is zero it should report 0 KiB", n: 0, want: "0 KiB"},
+		{name: "When the size is below one KiB it should report 1 KiB", n: 1, want: "1 KiB"},
+		{name: "When the size is exactly 1024 it should report 1 KiB", n: 1024, want: "1 KiB"},
+		{name: "When the size is 45 MiB it should report 45 MiB", n: 47185920, want: "45 MiB"},
+		{name: "When the size is 1 GiB it should report 1 GiB", n: 1 << 30, want: "1 GiB"},
+		{name: "When the size is 1 TiB it should report 1 TiB", n: 1 << 40, want: "1 TiB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, FormatIECBytes(tt.n))
+		})
+	}
+}
+
 func TestLookupCachedGeneration(t *testing.T) {
 	ctx := context.Background()
 	key := testGenerationKey()

--- a/internal/tasks/os_delta_hint_test.go
+++ b/internal/tasks/os_delta_hint_test.go
@@ -46,6 +46,67 @@ func testGenerationKey() delta.GenerationKey {
 	}
 }
 
+func TestImageRepositoryFromRef(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{name: "When the ref is a tag it should strip the tag", ref: "quay.io/acme/os:latest", want: "quay.io/acme/os"},
+		{name: "When the ref is digested it should strip the digest", ref: "quay.io/acme/os@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", want: "quay.io/acme/os"},
+		{name: "When the ref is empty it should return an error", ref: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ImageRepositoryFromRef(tt.ref)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHintFromGeneration(t *testing.T) {
+	deltaRef := "quay.io/acme/os@sha256:delta"
+	size := int64(47185920)
+	full := int64(1 << 30)
+
+	t.Run("When generation succeeded it should hint deltaRef and IEC size_bytes", func(t *testing.T) {
+		img, sz := hintFromGeneration(&model.DeltaGeneration{
+			Status:    model.DeltaGenerationSucceeded,
+			DeltaRef:  &deltaRef,
+			SizeBytes: &size,
+		}, nil)
+		require.Equal(t, &deltaRef, img)
+		require.Equal(t, lo.ToPtr("45 MiB"), sz)
+	})
+
+	t.Run("When generation is rejected it should not hint and should use size_bytes", func(t *testing.T) {
+		img, sz := hintFromGeneration(&model.DeltaGeneration{
+			Status:    model.DeltaGenerationRejected,
+			SizeBytes: &size,
+		}, nil)
+		require.Nil(t, img)
+		require.Equal(t, lo.ToPtr("45 MiB"), sz)
+	})
+
+	t.Run("When generation is missing it should not hint and should use fallback size", func(t *testing.T) {
+		img, sz := hintFromGeneration(nil, &full)
+		require.Nil(t, img)
+		require.Equal(t, lo.ToPtr("1 GiB"), sz)
+	})
+
+	t.Run("When generation failed without size_bytes it should use fallback size", func(t *testing.T) {
+		img, sz := hintFromGeneration(&model.DeltaGeneration{Status: model.DeltaGenerationFailed}, &full)
+		require.Nil(t, img)
+		require.Equal(t, lo.ToPtr("1 GiB"), sz)
+	})
+}
+
 func TestFormatIECBytes(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/worker_server/server.go
+++ b/internal/worker_server/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/flightctl/flightctl/internal/config"
+	deltaworker "github.com/flightctl/flightctl/internal/delta_worker"
 	"github.com/flightctl/flightctl/internal/instrumentation/encryption"
 	"github.com/flightctl/flightctl/internal/instrumentation/metrics/worker"
 	"github.com/flightctl/flightctl/internal/kvstore"
@@ -150,6 +151,7 @@ func (s *Server) Run(ctx context.Context) error {
 		QueuePublisher:     publisher,
 		WorkerClient:       workerClient,
 		DeltaStore:         deltaStore,
+		Preparing:          deltaworker.NewStorePreparingStatus(fleetStore, deviceStore),
 	}, 1, 1); err != nil {
 		s.log.WithError(err).Error("failed to launch consumers")
 		return err

--- a/internal/worker_server/server.go
+++ b/internal/worker_server/server.go
@@ -26,6 +26,7 @@ import (
 	canarystore "github.com/flightctl/flightctl/internal/store/canary"
 	catalogstore "github.com/flightctl/flightctl/internal/store/catalog"
 	checkpointstore "github.com/flightctl/flightctl/internal/store/checkpoint"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	dependencyrefstore "github.com/flightctl/flightctl/internal/store/dependencyref"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
 	eventstore "github.com/flightctl/flightctl/internal/store/event"
@@ -110,6 +111,7 @@ func (s *Server) Run(ctx context.Context) error {
 	canaryStore := canarystore.NewCanaryStore(s.db, s.log.WithField("pkg", "canary-store"))
 	canarySvc := canaryservice.WrapWithTracing(canaryservice.NewServiceHandler(canaryStore))
 	catStore := catalogstore.NewCatalogStore(s.db, s.log.WithField("pkg", "catalog-store"))
+	deltaStore := deltastore.NewStore(s.db, s.log.WithField("pkg", "delta-store"))
 
 	eventsSvc := events.NewServiceHandler(eventStore, workerClient, s.log)
 
@@ -147,6 +149,7 @@ func (s *Server) Run(ctx context.Context) error {
 		EncryptionMigrator: encryptionMigrator,
 		QueuePublisher:     publisher,
 		WorkerClient:       workerClient,
+		DeltaStore:         deltaStore,
 	}, 1, 1); err != nil {
 		s.log.WithError(err).Error("failed to launch consumers")
 		return err

--- a/test/integration/agent/agent_test.go
+++ b/test/integration/agent/agent_test.go
@@ -261,7 +261,7 @@ var _ = Describe("Device Agent behavior", func() {
 				// Update rendered once via the service so the rendered bus is notified (agent will see new version).
 				cfg, err := createMinimalRenderedConfig("config-v1")
 				Expect(err).ToNot(HaveOccurred())
-				st := h.Device.UpdateRenderedDevice(h.Context, orgID, deviceName, cfg, "", "hash1", "", nil, false)
+				st := h.Device.UpdateRenderedDevice(h.Context, orgID, deviceName, cfg, "", "hash1", "", nil, false, nil)
 				Expect(st.Code).To(BeEquivalentTo(200))
 				renderedDev, getErr := h.DeviceStore.GetRendered(h.Context, orgID, deviceName, nil, "")
 				Expect(getErr).ToNot(HaveOccurred())

--- a/test/integration/service/device_test.go
+++ b/test/integration/service/device_test.go
@@ -1764,7 +1764,7 @@ var _ = Describe("Device Application Status Events Integration Tests", func() {
 			renderedConfig, err := buildRenderedConfig("update-rendered-device-config")
 			Expect(err).ToNot(HaveOccurred())
 
-			status = suite.Device.UpdateRenderedDevice(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash1", "", nil, false)
+			status = suite.Device.UpdateRenderedDevice(suite.Ctx, suite.OrgID, deviceName, renderedConfig, "", "hash1", "", nil, false, nil)
 			Expect(status.Code).To(Equal(int32(200)))
 
 			updated, err := suite.DeviceStore.Get(suite.Ctx, suite.OrgID, deviceName)

--- a/test/integration/tasks/device_render_test.go
+++ b/test/integration/tasks/device_render_test.go
@@ -20,6 +20,7 @@ import (
 	templateversionservice "github.com/flightctl/flightctl/internal/service/templateversion"
 	"github.com/flightctl/flightctl/internal/store"
 	catalogstore "github.com/flightctl/flightctl/internal/store/catalog"
+	deltastore "github.com/flightctl/flightctl/internal/store/delta"
 	dependencyrefstore "github.com/flightctl/flightctl/internal/store/dependencyref"
 	devicestore "github.com/flightctl/flightctl/internal/store/device"
 	eventstore "github.com/flightctl/flightctl/internal/store/event"
@@ -1276,4 +1277,69 @@ var _ = Describe("DeviceRender", func() {
 				"redundant FleetRolloutDeviceSelected must not bump renderedVersion when already caught up")
 		})
 	})
+
+	Context("OS delta hint after prepare resume", func() {
+		It("When a succeeded generation exists GetRenderedDevice should expose deltaImage and IEC updated size", func() {
+			const (
+				srcDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+				tgtDigest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+				osImage   = "quay.io/acme/os@" + tgtDigest
+				deltaRef  = "quay.io/acme/os@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+			)
+			sizeBytes := int64(47185920)
+			testDeviceName := deviceName + "-os-delta-hint-" + uuid.New().String()[:8]
+
+			device := &api.Device{
+				Metadata: api.ObjectMeta{Name: lo.ToPtr(testDeviceName)},
+				Spec: &api.DeviceSpec{
+					Os: &api.DeviceOsSpec{Image: osImage},
+				},
+				Status: &api.DeviceStatus{
+					Os: api.DeviceOsStatus{ImageDigest: srcDigest},
+				},
+			}
+			_, err := deviceStore.Create(ctx, orgId, device, nil)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _, _ = deviceStore.Delete(ctx, orgId, testDeviceName, nil) }()
+
+			created, err := deviceStore.Get(ctx, orgId, testDeviceName)
+			Expect(err).ToNot(HaveOccurred())
+			if created.Status == nil {
+				created.Status = &api.DeviceStatus{}
+			}
+			created.Status.Os.ImageDigest = srcDigest
+			_, _, err = deviceStore.UpdateStatus(ctx, orgId, created, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			deltaStore := deltastore.NewStore(db, log.WithField("pkg", "delta-store"))
+			_, err = deltaStore.InsertGenerations(ctx, []*model.DeltaGeneration{{
+				OrgID:           orgId,
+				ImageRepository: "quay.io/acme/os",
+				SourceDigest:    srcDigest,
+				TargetDigest:    tgtDigest,
+				Status:          model.DeltaGenerationSucceeded,
+				DeltaRef:        lo.ToPtr(deltaRef),
+				SizeBytes:       &sizeBytes,
+			}})
+			Expect(err).ToNot(HaveOccurred())
+
+			event := api.Event{
+				Reason:         api.EventReasonResourceUpdated,
+				InvolvedObject: api.ObjectReference{Kind: api.DeviceKind, Name: testDeviceName},
+			}
+			logic := tasks.NewDeviceRenderLogic(log, deviceSvc, repositorySvc, nil, &mockK8sClient{}, kvStoreInst, nil, orgId, event).
+				WithDeltaLookup(deltaStore)
+			Expect(logic.RenderDevice(ctx)).To(Succeed())
+
+			renderedDevice, status := deviceSvc.GetRenderedDevice(ctx, orgId, testDeviceName, api.GetRenderedDeviceParams{})
+			Expect(status.Code).To(BeEquivalentTo(http.StatusOK))
+			Expect(renderedDevice).ToNot(BeNil())
+			Expect(renderedDevice.Spec).ToNot(BeNil())
+			Expect(renderedDevice.Spec.Os).ToNot(BeNil())
+			Expect(lo.FromPtr(renderedDevice.Spec.Os.DeltaImage)).To(Equal(deltaRef))
+			Expect(renderedDevice.Status).ToNot(BeNil())
+			Expect(lo.FromPtr(renderedDevice.Status.Updated.Size)).To(Equal("45 MiB"))
+		})
+	})
+
 })


### PR DESCRIPTION
# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-1.4`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.

## EDM-5224: RenderDevice sets OS deltaImage and Updated.Size

**Jira:** https://issues.redhat.com/browse/EDM-5224
**Story type:** [DEV]
**Stack:** sits on [EDM-5223](https://github.com/flightctl/flightctl/pull/3457) (`EDM-5223-hold-rollout-prepare-deltas`)

### Summary

After PrepareDeltas has resumed (EDM-5223), `RenderDevice` looks up `delta_generations` by `(org, image_repository, source digest, target digest)`, copies `spec.os.deltaImage` from a succeeded row’s `delta_ref`, and writes IEC `status.updated.size` from stored `size_bytes`. The rendered spec is always saved. Leftover `DeviceDeltaPreparing` is cleared on standalone devices only.

Render does **not** HEAD the registry, does **not** dual-miss regenerate (AC-3 deferred), and does **not** read `delta_prepares`. Generation lookup is memoized in Redis (15m TTL) so a fleet sharing one OS pair does one DB read per window.

### Changes

- `internal/tasks/os_delta_hint.go` — Redis memo, IEC size, `ImageRepositoryFromRef`, hint from generation status
- `internal/tasks/device_render.go` — apply OS hint/size after `renderSpec`; clear standalone `DeviceDeltaPreparing`
- `internal/service/device` / `internal/store/device` — `UpdateRenderedDevice` overlay for rendered `deltaImage` and `Updated.Size`
- `internal/tasks/consumer.go`, `internal/worker_server/server.go` — wire `DeltaStore` and preparing clearer
- Tests: unit (memo, IEC, hint, clear) + tasks integration (`GetRenderedDevice` after a succeeded generation)

### Testing

- **Unit tests:** memo HIT/MISS, IEC (`45 MiB`), succeeded hint, rejected/unfinished helper paths, standalone vs fleet preparing clear
- **Integration tests:** succeeded generation → `GetRenderedDevice` has `deltaImage` and IEC `status.updated.size`
- **Coverage:** new hint/size/clear contracts covered; full-image size is injectable only (`osManifestSize` is not wired in production — unfinished rows leave `Updated.Size` unset rather than inventing 0)

### Acceptance Criteria

- [x] AC-1: Always save the rendered spec; hints only after prepare resume (resume gate is EDM-5223)
- [x] AC-2: succeeded + `delta_ref` → `deltaImage`; any other status → unset (row status only; no live HEAD)
- [ ] AC-3: HEAD / dual-miss regenerate at render — **deferred** (out of this PR)
- [x] AC-4: rejected `size_bytes` still used; `Updated.Size` is OS-pair IEC only
- [x] AC-5: unfinished / missing row → no hint; full-image size only when `osManifestSize` is injected (production default: leave size unset)
- [x] AC-6: Clear leftover `DeviceDeltaPreparing` on standalone devices after successful persist
