### PR TITLE
EDM-5297: Implement OTLP/HTTP forwarding with custom headers

### DIFF
--- a/deploy/helm/flightctl/README.md
+++ b/deploy/helm/flightctl/README.md
@@ -410,6 +410,16 @@ For more detailed configuration options, see the [Values](#values) section below
 | remoteAccess.logLevel | string | `"info"` | Log level for the remote access service |
 | remoteAccess.resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource requests and limits for the remote access container |
 | telemetryGateway.additionalRouteLabels | string | `nil` |  |
+| telemetryGateway.extraEnvs | list | `[]` | Extra environment variables for the telemetry gateway container. Use to inject secrets for forward header values via ${VAR} expansion. |
+| telemetryGateway.extraVolumeMounts | list | `[]` | Extra volume mounts for the telemetry gateway container. Use to mount TLS certificates for mTLS forward connections. |
+| telemetryGateway.extraVolumes | list | `[]` | Extra volumes for the telemetry gateway pod. |
+| telemetryGateway.forward | object | `{"endpoint":"","headers":{},"tls":{"caFile":"","certFile":"","insecureSkipTlsVerify":false,"keyFile":""}}` | Forward telemetry to an upstream OTLP collector. Uses OTLP/gRPC for bare host:port endpoints, OTLP/HTTP for http(s):// URLs. Header values support ${ENV_VAR} expansion for secret injection. |
+| telemetryGateway.forward.endpoint | string | `""` | Upstream OTLP endpoint (e.g. "collector:4317" for gRPC, "https://host/api/v2/otlp" for HTTP) |
+| telemetryGateway.forward.headers | object | `{}` | Custom HTTP headers for authentication (only used with OTLP/HTTP endpoints). Values support ${ENV_VAR} expansion — use extraEnvs with secretKeyRef to avoid storing tokens in the ConfigMap. |
+| telemetryGateway.forward.tls.caFile | string | `""` | Path to CA certificate file |
+| telemetryGateway.forward.tls.certFile | string | `""` | Path to client certificate file (for mTLS) |
+| telemetryGateway.forward.tls.insecureSkipTlsVerify | bool | `false` | Skip TLS certificate verification |
+| telemetryGateway.forward.tls.keyFile | string | `""` | Path to client key file (for mTLS) |
 | telemetryGateway.image.image | string | `"quay.io/flightctl/flightctl-telemetry-gateway-el9"` | Telemetry gateway container image |
 | telemetryGateway.image.pullPolicy | string | `""` | Image pull policy for Telemetry gateway container |
 | telemetryGateway.image.tag | string | `""` | Telemetry gateway image tag |

--- a/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-config.yaml
+++ b/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-config.yaml
@@ -32,6 +32,31 @@ data:
     telemetryGateway:
       listen: { device: "0.0.0.0:4317" }
       export: { prometheus: "0.0.0.0:9464" }
+      {{- if .Values.telemetryGateway.forward.endpoint }}
+      forward:
+        endpoint: {{ .Values.telemetryGateway.forward.endpoint | quote }}
+        {{- with .Values.telemetryGateway.forward.headers }}
+        headers:
+          {{- range $key, $val := . }}
+          {{ $key }}: {{ $val | quote }}
+          {{- end }}
+        {{- end }}
+        {{- if or .Values.telemetryGateway.forward.tls.insecureSkipTlsVerify .Values.telemetryGateway.forward.tls.caFile .Values.telemetryGateway.forward.tls.certFile .Values.telemetryGateway.forward.tls.keyFile }}
+        tls:
+          {{- if .Values.telemetryGateway.forward.tls.insecureSkipTlsVerify }}
+          insecureSkipTlsVerify: true
+          {{- end }}
+          {{- if .Values.telemetryGateway.forward.tls.caFile }}
+          caFile: {{ .Values.telemetryGateway.forward.tls.caFile | quote }}
+          {{- end }}
+          {{- if .Values.telemetryGateway.forward.tls.certFile }}
+          certFile: {{ .Values.telemetryGateway.forward.tls.certFile | quote }}
+          {{- end }}
+          {{- if .Values.telemetryGateway.forward.tls.keyFile }}
+          keyFile: {{ .Values.telemetryGateway.forward.tls.keyFile | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
     {{- if (default dict .Values.dev).tracing }}
     tracing:
         enabled: true

--- a/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-deployment.yaml
+++ b/deploy/helm/flightctl/templates/telemetry-gateway/flightctl-telemetry-gateway-deployment.yaml
@@ -39,6 +39,9 @@ spec:
             secretKeyRef:
               name: {{ include "flightctl.dbAppUserSecret" . }}
               key: user
+        {{- with .Values.telemetryGateway.extraEnvs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         image: "{{ include "flightctl.ensureOsQualifiedImage" (dict "root" . "imageName" .Values.telemetryGateway.image.image) }}:{{ default .Chart.AppVersion .Values.telemetryGateway.image.tag }}"
         imagePullPolicy: {{ default .Values.global.imagePullPolicy .Values.telemetryGateway.image.pullPolicy }}
         name: telemetry-gateway
@@ -73,6 +76,9 @@ spec:
           name: telemetry-gateway-tls
           readOnly: true
           subPath: tls.key
+        {{- with .Values.telemetryGateway.extraVolumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       volumes:
@@ -85,3 +91,6 @@ spec:
       - name: flightctl-ca-bundle
         secret:
           secretName: flightctl-ca-bundle
+      {{- with .Values.telemetryGateway.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/deploy/helm/flightctl/values.schema.json
+++ b/deploy/helm/flightctl/values.schema.json
@@ -829,6 +829,48 @@
           "type": ["object", "null"],
           "description": "Additional labels for Telemetry gateway routes.",
           "additionalProperties": { "type": "string" }
+        },
+        "extraEnvs": {
+          "type": "array",
+          "description": "Extra environment variables for the telemetry gateway container. Use to inject secrets for forward header values via ${VAR} expansion.",
+          "items": { "type": "object" }
+        },
+        "extraVolumeMounts": {
+          "type": "array",
+          "description": "Extra volume mounts for the telemetry gateway container. Use to mount TLS certificates for mTLS forward connections.",
+          "items": { "type": "object" }
+        },
+        "extraVolumes": {
+          "type": "array",
+          "description": "Extra volumes for the telemetry gateway pod.",
+          "items": { "type": "object" }
+        },
+        "forward": {
+          "type": "object",
+          "description": "Forward telemetry to an upstream OTLP collector.",
+          "additionalProperties": false,
+          "properties": {
+            "endpoint": {
+              "type": "string",
+              "description": "Upstream OTLP endpoint. Use host:port for gRPC, http(s):// URL for OTLP/HTTP."
+            },
+            "headers": {
+              "type": "object",
+              "description": "Custom HTTP headers for authentication (OTLP/HTTP only).",
+              "additionalProperties": { "type": "string" }
+            },
+            "tls": {
+              "type": "object",
+              "description": "TLS configuration for the forward connection.",
+              "additionalProperties": false,
+              "properties": {
+                "insecureSkipTlsVerify": { "type": "boolean", "description": "Skip TLS certificate verification." },
+                "caFile": { "type": "string", "description": "Path to CA certificate file." },
+                "certFile": { "type": "string", "description": "Path to client certificate file (mTLS)." },
+                "keyFile": { "type": "string", "description": "Path to client key file (mTLS)." }
+              }
+            }
+          }
         }
       }
     },

--- a/deploy/helm/flightctl/values.yaml
+++ b/deploy/helm/flightctl/values.yaml
@@ -485,6 +485,33 @@ telemetryGateway:
     # -- Image pull policy for Telemetry gateway container
     pullPolicy: ""
   additionalRouteLabels: null
+  # -- Extra environment variables for the telemetry gateway container.
+  # Use to inject secrets for forward header values via ${VAR} expansion.
+  extraEnvs: []
+  # -- Extra volume mounts for the telemetry gateway container.
+  # Use to mount TLS certificates for mTLS forward connections.
+  extraVolumeMounts: []
+  # -- Extra volumes for the telemetry gateway pod.
+  extraVolumes: []
+  # -- Forward telemetry to an upstream OTLP collector.
+  # Uses OTLP/gRPC for bare host:port endpoints, OTLP/HTTP for http(s):// URLs.
+  # Header values support ${ENV_VAR} expansion for secret injection.
+  forward:
+    # -- Upstream OTLP endpoint (e.g. "collector:4317" for gRPC, "https://host/api/v2/otlp" for HTTP)
+    endpoint: ""
+    # -- Custom HTTP headers for authentication (only used with OTLP/HTTP endpoints).
+    # Values support ${ENV_VAR} expansion — use extraEnvs with secretKeyRef to avoid
+    # storing tokens in the ConfigMap.
+    headers: {}
+    tls:
+      # -- Skip TLS certificate verification
+      insecureSkipTlsVerify: false
+      # -- Path to CA certificate file
+      caFile: ""
+      # -- Path to client certificate file (for mTLS)
+      certFile: ""
+      # -- Path to client key file (for mTLS)
+      keyFile: ""
 
 # -- UI Configuration
 ui:

--- a/deploy/helm/flightctl/values.yaml.gotmpl
+++ b/deploy/helm/flightctl/values.yaml.gotmpl
@@ -485,6 +485,33 @@ telemetryGateway:
     # -- Image pull policy for Telemetry gateway container
     pullPolicy: ""
   additionalRouteLabels: null
+  # -- Extra environment variables for the telemetry gateway container.
+  # Use to inject secrets for forward header values via ${VAR} expansion.
+  extraEnvs: []
+  # -- Extra volume mounts for the telemetry gateway container.
+  # Use to mount TLS certificates for mTLS forward connections.
+  extraVolumeMounts: []
+  # -- Extra volumes for the telemetry gateway pod.
+  extraVolumes: []
+  # -- Forward telemetry to an upstream OTLP collector.
+  # Uses OTLP/gRPC for bare host:port endpoints, OTLP/HTTP for http(s):// URLs.
+  # Header values support ${ENV_VAR} expansion for secret injection.
+  forward:
+    # -- Upstream OTLP endpoint (e.g. "collector:4317" for gRPC, "https://host/api/v2/otlp" for HTTP)
+    endpoint: ""
+    # -- Custom HTTP headers for authentication (only used with OTLP/HTTP endpoints).
+    # Values support ${ENV_VAR} expansion — use extraEnvs with secretKeyRef to avoid
+    # storing tokens in the ConfigMap.
+    headers: {}
+    tls:
+      # -- Skip TLS certificate verification
+      insecureSkipTlsVerify: false
+      # -- Path to CA certificate file
+      caFile: ""
+      # -- Path to client certificate file (for mTLS)
+      certFile: ""
+      # -- Path to client key file (for mTLS)
+      keyFile: ""
 
 # -- UI Configuration
 ui:

--- a/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway-config/config.yaml.template
+++ b/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway-config/config.yaml.template
@@ -43,12 +43,18 @@ telemetryGateway:
       {{- end }}
       {{- if .telemetryGateway.forward.tls.caFile }}
       caFile: {{ .telemetryGateway.forward.tls.caFile }}
+      {{- else }}
+      caFile: /etc/flightctl/flightctl-telemetry-gateway/forward/ca.crt
       {{- end }}
       {{- if .telemetryGateway.forward.tls.certFile }}
       certFile: {{ .telemetryGateway.forward.tls.certFile }}
+      {{- else }}
+      certFile: /etc/flightctl/flightctl-telemetry-gateway/forward/client.crt
       {{- end }}
       {{- if .telemetryGateway.forward.tls.keyFile }}
       keyFile: {{ .telemetryGateway.forward.tls.keyFile }}
+      {{- else }}
+      keyFile: /etc/flightctl/flightctl-telemetry-gateway/forward/client.key
       {{- end }}
     {{- end }}
 {{- end}}

--- a/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway-config/config.yaml.template
+++ b/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway-config/config.yaml.template
@@ -30,10 +30,27 @@ telemetryGateway:
 {{- if .telemetryGateway.forward.endpoint }}
   forward:
     endpoint: {{.telemetryGateway.forward.endpoint}}
+    {{- with .telemetryGateway.forward.headers }}
+    headers:
+      {{- range $key, $val := . }}
+      {{ $key }}: {{ $val }}
+      {{- end }}
+    {{- end }}
+    {{- if or .telemetryGateway.forward.tls.insecureSkipTlsVerify .telemetryGateway.forward.tls.caFile .telemetryGateway.forward.tls.certFile .telemetryGateway.forward.tls.keyFile }}
     tls:
-      caFile: /etc/flightctl/flightctl-telemetry-gateway/forward/ca.crt
-      certFile: /etc/flightctl/flightctl-telemetry-gateway/forward/client.crt
-      keyFile: /etc/flightctl/flightctl-telemetry-gateway/forward/client.key
+      {{- if .telemetryGateway.forward.tls.insecureSkipTlsVerify }}
+      insecureSkipTlsVerify: true
+      {{- end }}
+      {{- if .telemetryGateway.forward.tls.caFile }}
+      caFile: {{ .telemetryGateway.forward.tls.caFile }}
+      {{- end }}
+      {{- if .telemetryGateway.forward.tls.certFile }}
+      certFile: {{ .telemetryGateway.forward.tls.certFile }}
+      {{- end }}
+      {{- if .telemetryGateway.forward.tls.keyFile }}
+      keyFile: {{ .telemetryGateway.forward.tls.keyFile }}
+      {{- end }}
+    {{- end }}
 {{- end}}
 
 {{- with .profiling }}

--- a/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway.container
+++ b/deploy/podman/flightctl-telemetry-gateway/flightctl-telemetry-gateway.container
@@ -21,6 +21,11 @@ Volume=/etc/flightctl/pki/ca-bundle.crt:/etc/telemetry-gateway/certs/ca.crt:ro,z
 Volume=/etc/flightctl/pki/db:/root/.flightctl/certs/db:ro,z
 Volume=/etc/flightctl/flightctl-telemetry-gateway/forward:/etc/flightctl/flightctl-telemetry-gateway/forward:ro,z
 
+# Optional: inject forward auth token from a Podman secret as an env var.
+# Create with: podman secret create flightctl-tg-forward-token - <<< "your-token"
+# Then reference ${FLIGHTCTL_FORWARD_TOKEN} in header values.
+# Secret=flightctl-tg-forward-token,type=env,target=FLIGHTCTL_FORWARD_TOKEN
+
 [Service]
 Restart=on-failure
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-telemetry-gateway/config.yaml.template --output-file /etc/flightctl/flightctl-telemetry-gateway/config.yaml

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/testcontainers/testcontainers-go v0.39.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.130.1
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.130.1
 	go.opentelemetry.io/otel/exporters/prometheus v0.59.1
 	go.opentelemetry.io/otel/sdk/metric v1.39.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -1055,6 +1055,8 @@ go.opentelemetry.io/collector/exporter/exportertest v0.130.1 h1:cCG38CzE0IYnAbs+
 go.opentelemetry.io/collector/exporter/exportertest v0.130.1/go.mod h1:AVMi+ZW9hOC2LkbXsVIQ6t7GDVeKyBSgaQO9yxmvuqg=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.130.1 h1:TM1lbvai7NUpvnFebhY/ZF9vGQvLKIQF0u+AJJ2/7tw=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.130.1/go.mod h1:rAuL1DjVX2URdTxQjWcJe75jQSdsOohiBWLV51H8Lj8=
+go.opentelemetry.io/collector/exporter/otlphttpexporter v0.130.1 h1:jF9GClXAoTIBQJHw2EAf9CrhQYryvk8Npa7/T9o5yQ4=
+go.opentelemetry.io/collector/exporter/otlphttpexporter v0.130.1/go.mod h1:mOE4DkGKAvKcg+7eA/kTHsKI7uSHfWoz9b7+DjDfSzs=
 go.opentelemetry.io/collector/exporter/xexporter v0.130.1 h1:IcNFpAGywDXJiYNgffjpgqCrICTkvpT14c+wLTykFwU=
 go.opentelemetry.io/collector/exporter/xexporter v0.130.1/go.mod h1:Wnlxqh1WNPpsSd6wdHv+X7nj/rXq9wEJ+eK31t7jTBA=
 go.opentelemetry.io/collector/extension v1.36.1 h1:7ggGDCQ3Tqo+X4DXX0ho7e7w/41XzpQL+fsYnK3soYk=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -945,6 +945,7 @@ type telemetryGatewayExport struct {
 
 type telemetryGatewayForward struct {
 	Endpoint string                      `json:"endpoint,omitempty"`
+	Headers  map[string]api.SecureString `json:"headers,omitempty"`
 	TLS      *telemetryGatewayForwardTLS `json:"tls,omitempty"`
 }
 

--- a/internal/telemetry_gateway/tg.go
+++ b/internal/telemetry_gateway/tg.go
@@ -270,6 +270,8 @@ func buildOTelConfigMap(cfg *config.Config) (map[string]any, error) {
 				}
 				exporterCfg["headers"] = headers
 			}
+		} else if len(fwd.Headers) > 0 {
+			return nil, fmt.Errorf("forward headers are only supported for http(s) endpoints")
 		}
 		exporters[exporterKey] = exporterCfg
 		exporterNames = append(exporterNames, exporterKey)

--- a/internal/telemetry_gateway/tg.go
+++ b/internal/telemetry_gateway/tg.go
@@ -3,7 +3,9 @@ package telemetrygateway
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/flightctl/flightctl/internal/config"
 	"github.com/flightctl/flightctl/internal/telemetry_gateway/deviceattrs"
@@ -18,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/provider/envprovider"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
@@ -121,8 +124,9 @@ func Run(ctx context.Context, cfg *config.Config, opts ...Option) error {
 					"env:OTEL_CONFIG_YAML",
 				},
 				ProviderFactories: []confmap.ProviderFactory{
-					envprovider.NewFactory(),
+					newStrictEnvProviderFactory(),
 				},
+				DefaultScheme: "env",
 			},
 		},
 		Factories: func() (otelcol.Factories, error) {
@@ -136,6 +140,7 @@ func Run(ctx context.Context, cfg *config.Config, opts ...Option) error {
 				},
 				Exporters: map[component.Type]exporter.Factory{
 					component.MustNewType("otlp"):                  otlpexporter.NewFactory(),
+					component.MustNewType("otlphttp"):              otlphttpexporter.NewFactory(),
 					component.MustNewType("prometheus"):            prometheusexporter.NewFactory(),
 					component.MustNewType("prometheusremotewrite"): prometheusremotewriteexporter.NewFactory(),
 				},
@@ -163,6 +168,61 @@ func Run(ctx context.Context, cfg *config.Config, opts ...Option) error {
 	return nil
 }
 
+func isHTTPEndpoint(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "http" || u.Scheme == "https"
+}
+
+func validateHTTPEndpoint(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("missing host in endpoint %q", endpoint)
+	}
+	if u.RawQuery != "" {
+		return fmt.Errorf("query strings are not supported in endpoint %q", endpoint)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("fragments are not supported in endpoint %q", endpoint)
+	}
+	return nil
+}
+
+// strictEnvProvider wraps the OTel envprovider but fails on undefined
+// environment variables instead of logging a warning and continuing
+// with an empty string.
+type strictEnvProvider struct {
+	inner confmap.Provider
+}
+
+func newStrictEnvProviderFactory() confmap.ProviderFactory {
+	return confmap.NewProviderFactory(func(ps confmap.ProviderSettings) confmap.Provider {
+		return &strictEnvProvider{inner: envprovider.NewFactory().Create(ps)}
+	})
+}
+
+func (p *strictEnvProvider) Retrieve(ctx context.Context, uri string, watcher confmap.WatcherFunc) (*confmap.Retrieved, error) {
+	if !strings.HasPrefix(uri, "env:") {
+		return nil, fmt.Errorf("%q uri is not supported by env provider", uri)
+	}
+	name := strings.TrimPrefix(uri, "env:")
+	if idx := strings.Index(name, ":-"); idx >= 0 {
+		name = name[:idx]
+	}
+	if _, ok := os.LookupEnv(name); !ok {
+		return nil, fmt.Errorf("undefined environment variable: %s", name)
+	}
+	return p.inner.Retrieve(ctx, uri, watcher)
+}
+
+func (p *strictEnvProvider) Scheme() string                     { return "env" }
+func (p *strictEnvProvider) Shutdown(ctx context.Context) error { return p.inner.Shutdown(ctx) }
+
 // buildOTelConfigMap builds the OTEL collector config.
 func buildOTelConfigMap(cfg *config.Config) (map[string]any, error) {
 	exporterNames := []string{}
@@ -175,29 +235,44 @@ func buildOTelConfigMap(cfg *config.Config) (map[string]any, error) {
 		exporterNames = append(exporterNames, "prometheus")
 	}
 	if cfg.TelemetryGateway.Forward != nil && cfg.TelemetryGateway.Forward.Endpoint != "" {
-		otlp := map[string]any{
-			"endpoint": cfg.TelemetryGateway.Forward.Endpoint,
+		fwd := cfg.TelemetryGateway.Forward
+		exporterCfg := map[string]any{
+			"endpoint": fwd.Endpoint,
 		}
-		if cfg.TelemetryGateway.Forward.TLS != nil {
+		if fwd.TLS != nil {
 			tls := map[string]any{}
-			if cfg.TelemetryGateway.Forward.TLS.InsecureSkipTlsVerify {
+			if fwd.TLS.InsecureSkipTlsVerify {
 				tls["insecure_skip_verify"] = true
 			}
-			if v := cfg.TelemetryGateway.Forward.TLS.CertFile; v != "" {
+			if v := fwd.TLS.CertFile; v != "" {
 				tls["cert_file"] = v
 			}
-			if v := cfg.TelemetryGateway.Forward.TLS.KeyFile; v != "" {
+			if v := fwd.TLS.KeyFile; v != "" {
 				tls["key_file"] = v
 			}
-			if v := cfg.TelemetryGateway.Forward.TLS.CAFile; v != "" {
+			if v := fwd.TLS.CAFile; v != "" {
 				tls["ca_file"] = v
 			}
 			if len(tls) > 0 {
-				otlp["tls"] = tls
+				exporterCfg["tls"] = tls
 			}
 		}
-		exporters["otlp"] = otlp
-		exporterNames = append(exporterNames, "otlp")
+		exporterKey := "otlp"
+		if isHTTPEndpoint(fwd.Endpoint) {
+			exporterKey = "otlphttp"
+			if err := validateHTTPEndpoint(fwd.Endpoint); err != nil {
+				return nil, fmt.Errorf("forward endpoint: %w", err)
+			}
+			if len(fwd.Headers) > 0 {
+				headers := make(map[string]string, len(fwd.Headers))
+				for k, v := range fwd.Headers {
+					headers[k] = v.Value()
+				}
+				exporterCfg["headers"] = headers
+			}
+		}
+		exporters[exporterKey] = exporterCfg
+		exporterNames = append(exporterNames, exporterKey)
 	}
 	if len(exporterNames) == 0 {
 		return nil, fmt.Errorf("no exporters configured")

--- a/internal/telemetry_gateway/tg_test.go
+++ b/internal/telemetry_gateway/tg_test.go
@@ -135,7 +135,7 @@ telemetrygateway:
 	}
 }
 
-func TestBuildOTelConfigMap_GRPCWithHeadersIgnored(t *testing.T) {
+func TestBuildOTelConfigMap_GRPCWithHeadersRejected(t *testing.T) {
 	cfg := forwardCfg(t, `
 telemetrygateway:
   forward:
@@ -144,14 +144,12 @@ telemetrygateway:
       Authorization: "Api-Token test"
 `)
 
-	root, err := buildOTelConfigMap(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := buildOTelConfigMap(cfg)
+	if err == nil {
+		t.Fatal("expected error when headers are set on a gRPC endpoint")
 	}
-
-	exporters := root["exporters"].(map[string]any)
-	if _, ok := exporters["otlp"]; !ok {
-		t.Error("expected 'otlp' exporter for gRPC endpoint even with headers set")
+	if !strings.Contains(err.Error(), "forward headers are only supported for http(s) endpoints") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 

--- a/internal/telemetry_gateway/tg_test.go
+++ b/internal/telemetry_gateway/tg_test.go
@@ -1,0 +1,425 @@
+package telemetrygateway
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flightctl/flightctl/internal/config"
+	"go.opentelemetry.io/collector/confmap"
+	"sigs.k8s.io/yaml"
+)
+
+func TestIsHTTPEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     bool
+	}{
+		{"bare host:port is gRPC", "collector.example.com:4317", false},
+		{"localhost:port is gRPC", "localhost:4317", false},
+		{"https URL", "https://abc123.live.dynatrace.com/api/v2/otlp", true},
+		{"http URL", "http://localhost:4318/v1/metrics", true},
+		{"HTTPS uppercase", "HTTPS://example.com/otlp", true},
+		{"mixed case", "Https://example.com", true},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHTTPEndpoint(tt.endpoint); got != tt.want {
+				t.Errorf("isHTTPEndpoint(%q) = %v, want %v", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}
+
+func forwardCfg(t *testing.T, yamlSnippet string) *config.Config {
+	t.Helper()
+	cfg := config.NewDefault()
+	if err := yaml.Unmarshal([]byte(yamlSnippet), cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	return cfg
+}
+
+func TestBuildOTelConfigMap_GRPCForward(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "collector.example.com:4317"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	exporters, ok := root["exporters"].(map[string]any)
+	if !ok {
+		t.Fatal("exporters not found in config")
+	}
+	if _, ok := exporters["otlp"]; !ok {
+		t.Error("expected 'otlp' exporter for bare host:port endpoint")
+	}
+	if _, ok := exporters["otlphttp"]; ok {
+		t.Error("unexpected 'otlphttp' exporter for bare host:port endpoint")
+	}
+}
+
+func TestBuildOTelConfigMap_HTTPForward(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "https://abc123.live.dynatrace.com/api/v2/otlp"
+    headers:
+      Authorization: "Api-Token dt0c01.xxxx"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	exporters, ok := root["exporters"].(map[string]any)
+	if !ok {
+		t.Fatal("exporters not found in config")
+	}
+	if _, ok := exporters["otlp"]; ok {
+		t.Error("unexpected 'otlp' exporter for HTTPS endpoint")
+	}
+
+	httpExp, ok := exporters["otlphttp"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'otlphttp' exporter for HTTPS endpoint")
+	}
+	if httpExp["endpoint"] != "https://abc123.live.dynatrace.com/api/v2/otlp" {
+		t.Errorf("unexpected endpoint: %v", httpExp["endpoint"])
+	}
+
+	headers, ok := httpExp["headers"].(map[string]string)
+	if !ok {
+		t.Fatal("expected headers in otlphttp exporter config")
+	}
+	if headers["Authorization"] != "Api-Token dt0c01.xxxx" {
+		t.Errorf("unexpected Authorization header: got %q", headers["Authorization"])
+	}
+}
+
+func TestBuildOTelConfigMap_HTTPForwardWithTLS(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "https://collector.example.com/v1/metrics"
+    tls:
+      insecureSkipTlsVerify: true
+      caFile: "/etc/ssl/ca.crt"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	exporters := root["exporters"].(map[string]any)
+	httpExp := exporters["otlphttp"].(map[string]any)
+	tlsCfg, ok := httpExp["tls"].(map[string]any)
+	if !ok {
+		t.Fatal("expected tls config in otlphttp exporter")
+	}
+	if tlsCfg["insecure_skip_verify"] != true {
+		t.Error("expected insecure_skip_verify=true")
+	}
+	if tlsCfg["ca_file"] != "/etc/ssl/ca.crt" {
+		t.Errorf("unexpected ca_file: %v", tlsCfg["ca_file"])
+	}
+}
+
+func TestBuildOTelConfigMap_GRPCWithHeadersIgnored(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "collector.example.com:4317"
+    headers:
+      Authorization: "Api-Token test"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	exporters := root["exporters"].(map[string]any)
+	if _, ok := exporters["otlp"]; !ok {
+		t.Error("expected 'otlp' exporter for gRPC endpoint even with headers set")
+	}
+}
+
+func TestBuildOTelConfigMap_HTTPForwardEnvVarNotExpanded(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "https://abc123.live.dynatrace.com/api/v2/otlp"
+    headers:
+      Authorization: "Api-Token ${TEST_DT_TOKEN}"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	exporters := root["exporters"].(map[string]any)
+	httpExp := exporters["otlphttp"].(map[string]any)
+	headers := httpExp["headers"].(map[string]string)
+	if headers["Authorization"] != "Api-Token ${TEST_DT_TOKEN}" {
+		t.Errorf("header value should be left unresolved for Collector expansion, got %q", headers["Authorization"])
+	}
+}
+
+func TestBuildOTelConfigMap_HTTPInPipelineExporters(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "https://ingest.example.com/v1/metrics"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	svc := root["service"].(map[string]any)
+	pipelines := svc["pipelines"].(map[string]any)
+	metrics := pipelines["metrics"].(map[string]any)
+	exporterNames := metrics["exporters"].([]string)
+
+	found := false
+	for _, name := range exporterNames {
+		if name == "otlphttp" {
+			found = true
+		}
+		if name == "otlp" {
+			t.Error("pipeline should use 'otlphttp', not 'otlp', for HTTPS endpoint")
+		}
+	}
+	if !found {
+		t.Error("expected 'otlphttp' in pipeline exporters")
+	}
+}
+
+func TestStrictEnvProvider(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		envVars map[string]string
+		wantErr bool
+	}{
+		{
+			"defined variable resolves",
+			`value: "${env:MY_TOKEN}"`,
+			map[string]string{"MY_TOKEN": "secret123"},
+			false,
+		},
+		{
+			"undefined variable fails",
+			`value: "${env:UNDEFINED_VAR}"`,
+			nil,
+			true,
+		},
+		{
+			"bare ${VAR} syntax resolves via DefaultScheme",
+			`value: "${MY_TOKEN}"`,
+			map[string]string{"MY_TOKEN": "secret123"},
+			false,
+		},
+		{
+			"bare ${VAR} syntax fails when undefined",
+			`value: "${MISSING_VAR}"`,
+			nil,
+			true,
+		},
+		{
+			"empty but defined variable is allowed",
+			`value: "${env:EMPTY_VAR}"`,
+			map[string]string{"EMPTY_VAR": ""},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+			t.Setenv("TEST_YAML", tt.yaml)
+
+			resolver, err := confmap.NewResolver(confmap.ResolverSettings{
+				URIs:              []string{"env:TEST_YAML"},
+				ProviderFactories: []confmap.ProviderFactory{newStrictEnvProviderFactory()},
+				DefaultScheme:     "env",
+			})
+			if err != nil {
+				t.Fatalf("creating resolver: %v", err)
+			}
+
+			_, err = resolver.Resolve(context.Background())
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildOTelConfigMap_HTTPForwardUndefinedEnvVarPassesThrough(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "https://abc123.live.dynatrace.com/api/v2/otlp"
+    headers:
+      Authorization: "Api-Token ${NONEXISTENT_TOKEN}"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("buildOTelConfigMap should not validate env vars, got: %v", err)
+	}
+
+	exporters := root["exporters"].(map[string]any)
+	httpExp := exporters["otlphttp"].(map[string]any)
+	headers := httpExp["headers"].(map[string]string)
+	if !strings.Contains(headers["Authorization"], "${NONEXISTENT_TOKEN}") {
+		t.Errorf("header should contain unresolved reference, got %q", headers["Authorization"])
+	}
+}
+
+func TestBuildOTelConfigMap_HTTPForwardWithFullTLS(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "https://collector.example.com/api/v2/otlp"
+    tls:
+      certFile: "/etc/ssl/client.crt"
+      keyFile: "/etc/ssl/client.key"
+      caFile: "/etc/ssl/ca.crt"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	exporters := root["exporters"].(map[string]any)
+	httpExp := exporters["otlphttp"].(map[string]any)
+	tlsCfg, ok := httpExp["tls"].(map[string]any)
+	if !ok {
+		t.Fatal("expected tls config in otlphttp exporter")
+	}
+	if tlsCfg["cert_file"] != "/etc/ssl/client.crt" {
+		t.Errorf("unexpected cert_file: %v", tlsCfg["cert_file"])
+	}
+	if tlsCfg["key_file"] != "/etc/ssl/client.key" {
+		t.Errorf("unexpected key_file: %v", tlsCfg["key_file"])
+	}
+	if tlsCfg["ca_file"] != "/etc/ssl/ca.crt" {
+		t.Errorf("unexpected ca_file: %v", tlsCfg["ca_file"])
+	}
+}
+
+func TestBuildOTelConfigMap_GRPCForwardWithTLS(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "collector.example.com:4317"
+    tls:
+      certFile: "/etc/ssl/client.crt"
+      keyFile: "/etc/ssl/client.key"
+      caFile: "/etc/ssl/ca.crt"
+`)
+
+	root, err := buildOTelConfigMap(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	exporters := root["exporters"].(map[string]any)
+	grpcExp, ok := exporters["otlp"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'otlp' exporter for gRPC endpoint")
+	}
+	tlsCfg, ok := grpcExp["tls"].(map[string]any)
+	if !ok {
+		t.Fatal("expected tls config in otlp exporter")
+	}
+	if tlsCfg["cert_file"] != "/etc/ssl/client.crt" {
+		t.Errorf("unexpected cert_file: %v", tlsCfg["cert_file"])
+	}
+	if tlsCfg["key_file"] != "/etc/ssl/client.key" {
+		t.Errorf("unexpected key_file: %v", tlsCfg["key_file"])
+	}
+	if tlsCfg["ca_file"] != "/etc/ssl/ca.crt" {
+		t.Errorf("unexpected ca_file: %v", tlsCfg["ca_file"])
+	}
+}
+
+func TestBuildOTelConfigMap_NoExportersError(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  export: null
+`)
+
+	_, err := buildOTelConfigMap(cfg)
+	if err == nil {
+		t.Fatal("expected error when no exporters configured")
+	}
+	if !strings.Contains(err.Error(), "no exporters configured") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestBuildOTelConfigMap_InvalidHTTPEndpointError(t *testing.T) {
+	cfg := forwardCfg(t, `
+telemetrygateway:
+  forward:
+    endpoint: "https://host/path?key=val"
+`)
+
+	_, err := buildOTelConfigMap(cfg)
+	if err == nil {
+		t.Fatal("expected error for HTTP endpoint with query string")
+	}
+	if !strings.Contains(err.Error(), "forward endpoint") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestValidateHTTPEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		wantErr  bool
+	}{
+		{"valid https URL", "https://host/api/v2/otlp", false},
+		{"valid with trailing slash", "https://host/api/v2/otlp/", false},
+		{"valid with port", "https://host:443/api/v2/otlp", false},
+		{"missing host", "https://", true},
+		{"missing host with path", "https:///path", true},
+		{"has query string", "https://host/path?key=val", true},
+		{"has fragment", "https://host/path#section", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHTTPEndpoint(tt.endpoint)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q", tt.endpoint)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.endpoint, err)
+			}
+		})
+	}
+}

--- a/test/integration/telemetry_gateway/telemetry_gateway_test.go
+++ b/test/integration/telemetry_gateway/telemetry_gateway_test.go
@@ -392,25 +392,11 @@ service:
 			defer cancel()
 			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
 
-			Eventually(func() bool {
-				req := httpMC.lastRequest()
-				if req == nil {
-					return false
-				}
-				for _, rm := range req.metrics.ResourceMetrics {
-					for _, sm := range rm.ScopeMetrics {
-						for _, m := range sm.Metrics {
-							if m.GetName() == "test_tg_metric" {
-								return true
-							}
-						}
-					}
-				}
-				return false
-			}, timeout, polling).Should(BeTrue(), "HTTP collector did not receive forwarded metric")
+			Eventually(func() *httpOTLPRequest {
+				return httpMC.findRequestByMetric("test_tg_metric")
+			}, timeout, polling).ShouldNot(BeNil(), "HTTP collector did not receive forwarded metric")
 
-			req := httpMC.lastRequest()
-			Expect(req).ToNot(BeNil())
+			req := httpMC.findRequestByMetric("test_tg_metric")
 			Expect(req.headers.Get("Authorization")).To(Equal("Api-Token test-token-123"))
 			Expect(req.headers.Get("X-Custom-Header")).To(Equal("custom-value"))
 			verifyDeviceAttrs(req.metrics, "test_tg_metric", "testdevice")
@@ -476,25 +462,11 @@ service:
 			defer cancel()
 			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
 
-			Eventually(func() bool {
-				req := httpMC.lastRequest()
-				if req == nil {
-					return false
-				}
-				for _, rm := range req.metrics.ResourceMetrics {
-					for _, sm := range rm.ScopeMetrics {
-						for _, m := range sm.Metrics {
-							if m.GetName() == "test_tg_metric" {
-								return true
-							}
-						}
-					}
-				}
-				return false
-			}, timeout, polling).Should(BeTrue(), "HTTP collector did not receive forwarded metric")
+			Eventually(func() *httpOTLPRequest {
+				return httpMC.findRequestByMetric("test_tg_metric")
+			}, timeout, polling).ShouldNot(BeNil(), "HTTP collector did not receive forwarded metric")
 
-			req := httpMC.lastRequest()
-			Expect(req).ToNot(BeNil())
+			req := httpMC.findRequestByMetric("test_tg_metric")
 			Expect(req.headers.Get("Authorization")).To(Equal("Api-Token secret-token-from-env"))
 			verifyDeviceAttrs(req.metrics, "test_tg_metric", "testdevice")
 		})
@@ -557,24 +529,11 @@ service:
 			defer cancel()
 			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
 
-			Eventually(func() bool {
-				req := httpMC.lastRequest()
-				if req == nil {
-					return false
-				}
-				for _, rm := range req.metrics.ResourceMetrics {
-					for _, sm := range rm.ScopeMetrics {
-						for _, m := range sm.Metrics {
-							if m.GetName() == "test_tg_metric" {
-								return true
-							}
-						}
-					}
-				}
-				return false
-			}, timeout, polling).Should(BeTrue(), "HTTP collector did not receive forwarded metric")
+			Eventually(func() *httpOTLPRequest {
+				return httpMC.findRequestByMetric("test_tg_metric")
+			}, timeout, polling).ShouldNot(BeNil(), "HTTP collector did not receive forwarded metric")
 
-			verifyDeviceAttrs(httpMC.lastRequest().metrics, "test_tg_metric", "testdevice")
+			verifyDeviceAttrs(httpMC.findRequestByMetric("test_tg_metric").metrics, "test_tg_metric", "testdevice")
 		})
 	})
 
@@ -653,24 +612,11 @@ service:
 			defer cancel()
 			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
 
-			Eventually(func() bool {
-				req := httpMC.lastRequest()
-				if req == nil {
-					return false
-				}
-				for _, rm := range req.metrics.ResourceMetrics {
-					for _, sm := range rm.ScopeMetrics {
-						for _, m := range sm.Metrics {
-							if m.GetName() == "test_tg_metric" {
-								return true
-							}
-						}
-					}
-				}
-				return false
-			}, timeout, polling).Should(BeTrue(), "HTTP mTLS collector did not receive forwarded metric")
+			Eventually(func() *httpOTLPRequest {
+				return httpMC.findRequestByMetric("test_tg_metric")
+			}, timeout, polling).ShouldNot(BeNil(), "HTTP mTLS collector did not receive forwarded metric")
 
-			verifyDeviceAttrs(httpMC.lastRequest().metrics, "test_tg_metric", "testdevice")
+			verifyDeviceAttrs(httpMC.findRequestByMetric("test_tg_metric").metrics, "test_tg_metric", "testdevice")
 		})
 	})
 
@@ -935,6 +881,8 @@ service:
 
 func verifyDeviceAttrs(req *collectormetrics.ExportMetricsServiceRequest, metricName, expectedDeviceID string) {
 	GinkgoHelper()
+	Expect(req).ToNot(BeNil())
+	found := false
 	for _, rm := range req.ResourceMetrics {
 		var deviceID, orgID string
 		for _, attr := range rm.Resource.Attributes {
@@ -953,6 +901,7 @@ func verifyDeviceAttrs(req *collectormetrics.ExportMetricsServiceRequest, metric
 				if m.GetName() != metricName {
 					continue
 				}
+				found = true
 				dp := m.GetSum().GetDataPoints()
 				Expect(dp).ToNot(BeEmpty())
 				attrs := dp[0].GetAttributes()
@@ -970,6 +919,7 @@ func verifyDeviceAttrs(req *collectormetrics.ExportMetricsServiceRequest, metric
 			}
 		}
 	}
+	Expect(found).To(BeTrue(), "metric %q not found in request", metricName)
 }
 
 func createConfig(serverCrt string, serverKey string, caPath string, otlpAddr string) *config.Config {
@@ -1134,13 +1084,23 @@ type mockHTTPOTLPCollector struct {
 	reqs []httpOTLPRequest
 }
 
-func (m *mockHTTPOTLPCollector) lastRequest() *httpOTLPRequest {
+func (m *mockHTTPOTLPCollector) findRequestByMetric(name string) *httpOTLPRequest {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if len(m.reqs) == 0 {
-		return nil
+	for i := range m.reqs {
+		for _, rm := range m.reqs[i].metrics.ResourceMetrics {
+			for _, sm := range rm.ScopeMetrics {
+				for _, metric := range sm.Metrics {
+					if metric.GetName() == name {
+						req := m.reqs[i]
+						req.headers = req.headers.Clone()
+						return &req
+					}
+				}
+			}
+		}
 	}
-	return &m.reqs[len(m.reqs)-1]
+	return nil
 }
 
 func (m *mockHTTPOTLPCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/test/integration/telemetry_gateway/telemetry_gateway_test.go
+++ b/test/integration/telemetry_gateway/telemetry_gateway_test.go
@@ -1,18 +1,21 @@
 package telemetry_gateway_test
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,6 +35,7 @@ import (
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/yaml"
 )
 
@@ -306,15 +310,16 @@ service:
 			defer cancel()
 			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
 
-			// Assert the downstream collector received it
+			// Assert the downstream collector received it with device attributes
+			var forwardedReq *collectormetrics.ExportMetricsServiceRequest
 			Eventually(func() bool {
 				select {
 				case req := <-forwardMC.ch:
-					// sanity: does it contain "test_tg_metric"?
 					for _, rm := range req.ResourceMetrics {
 						for _, sm := range rm.ScopeMetrics {
 							for _, m := range sm.Metrics {
 								if m.GetName() == "test_tg_metric" {
+									forwardedReq = req
 									return true
 								}
 							}
@@ -325,6 +330,347 @@ service:
 					return false
 				}
 			}, timeout, polling).Should(BeTrue(), "downstream collector did not receive forwarded metric")
+
+			verifyDeviceAttrs(forwardedReq, "test_tg_metric", "testdevice")
+		})
+	})
+
+	Context("HTTP forwarding", func() {
+		var (
+			httpStop func()
+			httpMC   *mockHTTPOTLPCollector
+		)
+
+		BeforeEach(func() {
+			dsPriv, dsCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.ServerSvcSignerName, "svc-http-collector", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			endpoint, stop, mc, startErr := startMockHTTPCollector(dsCert, dsPriv)
+			Expect(startErr).ToNot(HaveOccurred())
+			httpStop, httpMC = stop, mc
+
+			cfgMutators = append(cfgMutators, func(c *config.Config) {
+				snippet := fmt.Appendf(nil,
+					"telemetrygateway:\n  export: null\n  forward:\n    endpoint: %q\n    headers:\n      Authorization: \"Api-Token test-token-123\"\n      X-Custom-Header: \"custom-value\"\n    tls:\n      insecureSkipTlsVerify: true\n",
+					endpoint,
+				)
+				_ = yaml.Unmarshal(snippet, c)
+			})
+		})
+
+		AfterEach(func() {
+			if httpStop != nil {
+				httpStop()
+			}
+		})
+
+		It("forwards metrics via OTLP/HTTP with custom headers", func() {
+			clientPrivateKey, clientCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.DeviceSvcClientSignerName, "client-testdevice", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			caPool := x509.NewCertPool()
+			for _, cert := range caClient.GetCABundleX509() {
+				caPool.AddCert(cert)
+			}
+
+			tlsCfg := &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    caPool,
+				Certificates: []tls.Certificate{{
+					Certificate: [][]byte{clientCert.Raw},
+					PrivateKey:  clientPrivateKey,
+				}},
+				ServerName: "localhost",
+			}
+
+			creds := credentials.NewTLS(tlsCfg)
+			cc, err := grpc.NewClient(otlpAddr, grpc.WithTransportCredentials(creds))
+			Expect(err).ToNot(HaveOccurred())
+			defer cc.Close()
+
+			rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
+
+			Eventually(func() bool {
+				req := httpMC.lastRequest()
+				if req == nil {
+					return false
+				}
+				for _, rm := range req.metrics.ResourceMetrics {
+					for _, sm := range rm.ScopeMetrics {
+						for _, m := range sm.Metrics {
+							if m.GetName() == "test_tg_metric" {
+								return true
+							}
+						}
+					}
+				}
+				return false
+			}, timeout, polling).Should(BeTrue(), "HTTP collector did not receive forwarded metric")
+
+			req := httpMC.lastRequest()
+			Expect(req).ToNot(BeNil())
+			Expect(req.headers.Get("Authorization")).To(Equal("Api-Token test-token-123"))
+			Expect(req.headers.Get("X-Custom-Header")).To(Equal("custom-value"))
+			verifyDeviceAttrs(req.metrics, "test_tg_metric", "testdevice")
+		})
+	})
+
+	Context("HTTP forwarding with env var expansion in headers", func() {
+		var (
+			httpStop func()
+			httpMC   *mockHTTPOTLPCollector
+		)
+
+		BeforeEach(func() {
+			dsPriv, dsCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.ServerSvcSignerName, "svc-http-collector", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			endpoint, stop, mc, startErr := startMockHTTPCollector(dsCert, dsPriv)
+			Expect(startErr).ToNot(HaveOccurred())
+			httpStop, httpMC = stop, mc
+
+			GinkgoT().Setenv("TEST_FORWARD_TOKEN", "secret-token-from-env")
+
+			cfgMutators = append(cfgMutators, func(c *config.Config) {
+				snippet := fmt.Appendf(nil,
+					"telemetrygateway:\n  export: null\n  forward:\n    endpoint: %q\n    headers:\n      Authorization: \"Api-Token ${TEST_FORWARD_TOKEN}\"\n    tls:\n      insecureSkipTlsVerify: true\n",
+					endpoint,
+				)
+				_ = yaml.Unmarshal(snippet, c)
+			})
+		})
+
+		AfterEach(func() {
+			if httpStop != nil {
+				httpStop()
+			}
+		})
+
+		It("When a header uses ${VAR} syntax it should resolve the env var and forward the value", func() {
+			clientPrivateKey, clientCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.DeviceSvcClientSignerName, "client-testdevice", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			caPool := x509.NewCertPool()
+			for _, cert := range caClient.GetCABundleX509() {
+				caPool.AddCert(cert)
+			}
+
+			tlsCfg := &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    caPool,
+				Certificates: []tls.Certificate{{
+					Certificate: [][]byte{clientCert.Raw},
+					PrivateKey:  clientPrivateKey,
+				}},
+				ServerName: "localhost",
+			}
+
+			creds := credentials.NewTLS(tlsCfg)
+			cc, err := grpc.NewClient(otlpAddr, grpc.WithTransportCredentials(creds))
+			Expect(err).ToNot(HaveOccurred())
+			defer cc.Close()
+
+			rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
+
+			Eventually(func() bool {
+				req := httpMC.lastRequest()
+				if req == nil {
+					return false
+				}
+				for _, rm := range req.metrics.ResourceMetrics {
+					for _, sm := range rm.ScopeMetrics {
+						for _, m := range sm.Metrics {
+							if m.GetName() == "test_tg_metric" {
+								return true
+							}
+						}
+					}
+				}
+				return false
+			}, timeout, polling).Should(BeTrue(), "HTTP collector did not receive forwarded metric")
+
+			req := httpMC.lastRequest()
+			Expect(req).ToNot(BeNil())
+			Expect(req.headers.Get("Authorization")).To(Equal("Api-Token secret-token-from-env"))
+			verifyDeviceAttrs(req.metrics, "test_tg_metric", "testdevice")
+		})
+	})
+
+	Context("HTTP forwarding without custom headers", func() {
+		var (
+			httpStop func()
+			httpMC   *mockHTTPOTLPCollector
+		)
+
+		BeforeEach(func() {
+			dsPriv, dsCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.ServerSvcSignerName, "svc-http-collector", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			endpoint, stop, mc, startErr := startMockHTTPCollector(dsCert, dsPriv)
+			Expect(startErr).ToNot(HaveOccurred())
+			httpStop, httpMC = stop, mc
+
+			cfgMutators = append(cfgMutators, func(c *config.Config) {
+				snippet := fmt.Appendf(nil,
+					"telemetrygateway:\n  export: null\n  forward:\n    endpoint: %q\n    tls:\n      insecureSkipTlsVerify: true\n",
+					endpoint,
+				)
+				_ = yaml.Unmarshal(snippet, c)
+			})
+		})
+
+		AfterEach(func() {
+			if httpStop != nil {
+				httpStop()
+			}
+		})
+
+		It("forwards metrics via OTLP/HTTP without headers", func() {
+			clientPrivateKey, clientCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.DeviceSvcClientSignerName, "client-testdevice", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			caPool := x509.NewCertPool()
+			for _, cert := range caClient.GetCABundleX509() {
+				caPool.AddCert(cert)
+			}
+
+			tlsCfg := &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    caPool,
+				Certificates: []tls.Certificate{{
+					Certificate: [][]byte{clientCert.Raw},
+					PrivateKey:  clientPrivateKey,
+				}},
+				ServerName: "localhost",
+			}
+
+			creds := credentials.NewTLS(tlsCfg)
+			cc, err := grpc.NewClient(otlpAddr, grpc.WithTransportCredentials(creds))
+			Expect(err).ToNot(HaveOccurred())
+			defer cc.Close()
+
+			rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
+
+			Eventually(func() bool {
+				req := httpMC.lastRequest()
+				if req == nil {
+					return false
+				}
+				for _, rm := range req.metrics.ResourceMetrics {
+					for _, sm := range rm.ScopeMetrics {
+						for _, m := range sm.Metrics {
+							if m.GetName() == "test_tg_metric" {
+								return true
+							}
+						}
+					}
+				}
+				return false
+			}, timeout, polling).Should(BeTrue(), "HTTP collector did not receive forwarded metric")
+
+			verifyDeviceAttrs(httpMC.lastRequest().metrics, "test_tg_metric", "testdevice")
+		})
+	})
+
+	Context("HTTP forwarding with mTLS", func() {
+		var (
+			httpStop func()
+			httpMC   *mockHTTPOTLPCollector
+		)
+
+		BeforeEach(func() {
+			// Server cert for downstream HTTP collector
+			dsPriv, dsCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.ServerSvcSignerName, "svc-http-mtls-collector", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Start mock HTTP collector that requires client certs
+			clientCAPool := x509.NewCertPool()
+			for _, c := range caClient.GetCABundleX509() {
+				clientCAPool.AddCert(c)
+			}
+			endpoint, stop, mc, startErr := startMockHTTPCollectorWithClientAuth(dsCert, dsPriv, clientCAPool)
+			Expect(startErr).ToNot(HaveOccurred())
+			httpStop, httpMC = stop, mc
+
+			// Client cert for the gateway when dialing downstream
+			fwdCliPriv, fwdCliCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.DeviceSvcClientSignerName, "client-gateway-http-forwarder", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			caPath := filepath.Join(testDirPath, "etc", "flightctl", "certs", "ca.crt")
+			forwardCrt := filepath.Join(testDirPath, "etc", "flightctl", "certs", fmt.Sprintf("fwd-http-%d.crt", time.Now().UnixNano()))
+			forwardKey := filepath.Join(testDirPath, "etc", "flightctl", "certs", fmt.Sprintf("fwd-http-%d.key", time.Now().UnixNano()))
+			certPEM, _ := fccrypto.EncodeCertificatePEM(fwdCliCert)
+			keyPEM, _ := fccrypto.PEMEncodeKey(fwdCliPriv)
+			Expect(os.WriteFile(forwardCrt, certPEM, 0o600)).To(Succeed())
+			Expect(os.WriteFile(forwardKey, keyPEM, 0o600)).To(Succeed())
+
+			cfgMutators = append(cfgMutators, func(c *config.Config) {
+				snippet := fmt.Appendf(nil,
+					"telemetrygateway:\n  export: null\n  forward:\n    endpoint: %q\n    tls:\n      certFile: %q\n      keyFile: %q\n      caFile: %q\n",
+					endpoint, forwardCrt, forwardKey, caPath,
+				)
+				_ = yaml.Unmarshal(snippet, c)
+			})
+		})
+
+		AfterEach(func() {
+			if httpStop != nil {
+				httpStop()
+			}
+		})
+
+		It("forwards metrics via OTLP/HTTP using client certificates", func() {
+			clientPrivateKey, clientCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.DeviceSvcClientSignerName, "client-testdevice", 365)
+			Expect(err).ToNot(HaveOccurred())
+
+			caPool := x509.NewCertPool()
+			for _, cert := range caClient.GetCABundleX509() {
+				caPool.AddCert(cert)
+			}
+
+			tlsCfg := &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    caPool,
+				Certificates: []tls.Certificate{{
+					Certificate: [][]byte{clientCert.Raw},
+					PrivateKey:  clientPrivateKey,
+				}},
+				ServerName: "localhost",
+			}
+
+			creds := credentials.NewTLS(tlsCfg)
+			cc, err := grpc.NewClient(otlpAddr, grpc.WithTransportCredentials(creds))
+			Expect(err).ToNot(HaveOccurred())
+			defer cc.Close()
+
+			rpcCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			Expect(exportTestMetrics(rpcCtx, cc)).To(Succeed())
+
+			Eventually(func() bool {
+				req := httpMC.lastRequest()
+				if req == nil {
+					return false
+				}
+				for _, rm := range req.metrics.ResourceMetrics {
+					for _, sm := range rm.ScopeMetrics {
+						for _, m := range sm.Metrics {
+							if m.GetName() == "test_tg_metric" {
+								return true
+							}
+						}
+					}
+				}
+				return false
+			}, timeout, polling).Should(BeTrue(), "HTTP mTLS collector did not receive forwarded metric")
+
+			verifyDeviceAttrs(httpMC.lastRequest().metrics, "test_tg_metric", "testdevice")
 		})
 	})
 
@@ -431,7 +777,8 @@ service:
 				return receiveTestMetrics(ctx, promAddr)
 			}, timeout, polling).Should(BeNil())
 
-			// Assert downstream collector received it via forward
+			// Assert downstream collector received it via forward with device attributes
+			var overlayForwardedReq *collectormetrics.ExportMetricsServiceRequest
 			Eventually(func() bool {
 				select {
 				case req := <-forwardMC.ch:
@@ -439,6 +786,7 @@ service:
 						for _, sm := range rm.ScopeMetrics {
 							for _, m := range sm.Metrics {
 								if m.GetName() == "test_tg_metric" {
+									overlayForwardedReq = req
 									return true
 								}
 							}
@@ -449,9 +797,180 @@ service:
 					return false
 				}
 			}, timeout, polling).Should(BeTrue(), "downstream collector did not receive forwarded metric")
+
+			verifyDeviceAttrs(overlayForwardedReq, "test_tg_metric", "testdevice")
 		})
 	})
 })
+
+var _ = Describe("Telemetry Gateway startup failure", func() {
+	It("When TLS cert files do not exist it should fail to start", func() {
+		ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+		testDirPath := GinkgoT().TempDir()
+
+		// CA
+		caCfg := ca.NewDefault(testDirPath)
+		caClient, _, err := icrypto.EnsureCA(caCfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		// CA bundle on disk
+		caPath := filepath.Join(testDirPath, "etc", "flightctl", "certs", "ca.crt")
+		Expect(os.MkdirAll(filepath.Dir(caPath), 0o755)).To(Succeed())
+		caBundle, err := caClient.GetCABundle()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(caPath, caBundle, 0o600)).To(Succeed())
+
+		// Server keypair
+		serverPriv, serverCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.ServerSvcSignerName, "svc-telemetry-gateway", 365)
+		Expect(err).ToNot(HaveOccurred())
+		serverCrt := filepath.Join(testDirPath, "etc", "flightctl", "certs", "telemetry-gateway.crt")
+		serverKey := filepath.Join(testDirPath, "etc", "flightctl", "certs", "telemetry-gateway.key")
+		certPEM, _ := fccrypto.EncodeCertificatePEM(serverCert)
+		keyPEM, _ := fccrypto.PEMEncodeKey(serverPriv)
+		Expect(os.WriteFile(serverCrt, certPEM, 0o600)).To(Succeed())
+		Expect(os.WriteFile(serverKey, keyPEM, 0o600)).To(Succeed())
+
+		otlpAddr := localAddr()
+		cfg := createConfig(serverCrt, serverKey, caPath, otlpAddr)
+
+		// Configure forward with TLS cert paths that do not exist
+		snippet := fmt.Appendf(nil,
+			"telemetrygateway:\n  export: null\n  forward:\n    endpoint: \"collector.example.com:4317\"\n    tls:\n      certFile: \"/nonexistent/path/client.crt\"\n      keyFile: \"/nonexistent/path/client.key\"\n      caFile: \"/nonexistent/path/ca.crt\"\n",
+		)
+		Expect(yaml.Unmarshal(snippet, cfg)).To(Succeed())
+
+		otelMetricsPort := localAddr()
+		_, port, _ := net.SplitHostPort(otelMetricsPort)
+
+		gwDone := make(chan error, 1)
+		gwCtx, gwCancel := context.WithCancel(ctx)
+		defer gwCancel()
+		go func() {
+			gwDone <- telemetrygateway.Run(gwCtx, cfg,
+				telemetrygateway.WithSkipSettingGRPCLogger(true),
+				telemetrygateway.WithOTelYAMLOverlay(fmt.Sprintf(`
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: localhost
+                port: %s
+`, port)),
+			)
+		}()
+
+		var gwErr error
+		Eventually(gwDone, timeout).Should(Receive(&gwErr))
+		Expect(gwErr).To(HaveOccurred())
+		Expect(errors.Is(gwErr, os.ErrNotExist)).To(BeTrue(), "expected file-not-found error, got: %v", gwErr)
+	})
+
+	It("When a header references an undefined env var it should fail to start", func() {
+		ctx := testutil.StartSpecTracerForGinkgo(suiteCtx)
+		testDirPath := GinkgoT().TempDir()
+
+		// CA
+		caCfg := ca.NewDefault(testDirPath)
+		caClient, _, err := icrypto.EnsureCA(caCfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		// CA bundle on disk
+		caPath := filepath.Join(testDirPath, "etc", "flightctl", "certs", "ca.crt")
+		Expect(os.MkdirAll(filepath.Dir(caPath), 0o755)).To(Succeed())
+		caBundle, err := caClient.GetCABundle()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(caPath, caBundle, 0o600)).To(Succeed())
+
+		// Server keypair
+		serverPriv, serverCert, err := makeKeyPairAndCSR(ctx, caClient, caClient.Cfg.ServerSvcSignerName, "svc-telemetry-gateway", 365)
+		Expect(err).ToNot(HaveOccurred())
+		serverCrt := filepath.Join(testDirPath, "etc", "flightctl", "certs", "telemetry-gateway.crt")
+		serverKey := filepath.Join(testDirPath, "etc", "flightctl", "certs", "telemetry-gateway.key")
+		certPEM, _ := fccrypto.EncodeCertificatePEM(serverCert)
+		keyPEM, _ := fccrypto.PEMEncodeKey(serverPriv)
+		Expect(os.WriteFile(serverCrt, certPEM, 0o600)).To(Succeed())
+		Expect(os.WriteFile(serverKey, keyPEM, 0o600)).To(Succeed())
+
+		otlpAddr := localAddr()
+		cfg := createConfig(serverCrt, serverKey, caPath, otlpAddr)
+
+		// Configure HTTP forward with an undefined env var in header
+		snippet := fmt.Appendf(nil,
+			"telemetrygateway:\n  export: null\n  forward:\n    endpoint: \"https://collector.example.com/api/v2/otlp\"\n    headers:\n      Authorization: \"Bearer ${UNDEFINED_SECRET_VAR}\"\n    tls:\n      insecureSkipTlsVerify: true\n",
+		)
+		Expect(yaml.Unmarshal(snippet, cfg)).To(Succeed())
+
+		otelMetricsPort := localAddr()
+		_, port, _ := net.SplitHostPort(otelMetricsPort)
+
+		gwDone := make(chan error, 1)
+		gwCtx, gwCancel := context.WithCancel(ctx)
+		defer gwCancel()
+		go func() {
+			gwDone <- telemetrygateway.Run(gwCtx, cfg,
+				telemetrygateway.WithSkipSettingGRPCLogger(true),
+				telemetrygateway.WithOTelYAMLOverlay(fmt.Sprintf(`
+service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: localhost
+                port: %s
+`, port)),
+			)
+		}()
+
+		var gwErr error
+		Eventually(gwDone, timeout).Should(Receive(&gwErr))
+		Expect(gwErr).To(HaveOccurred())
+		Expect(gwErr.Error()).To(ContainSubstring("UNDEFINED_SECRET_VAR"))
+	})
+})
+
+func verifyDeviceAttrs(req *collectormetrics.ExportMetricsServiceRequest, metricName, expectedDeviceID string) {
+	GinkgoHelper()
+	for _, rm := range req.ResourceMetrics {
+		var deviceID, orgID string
+		for _, attr := range rm.Resource.Attributes {
+			switch attr.Key {
+			case "device_id":
+				deviceID = attr.Value.GetStringValue()
+			case "org_id":
+				orgID = attr.Value.GetStringValue()
+			}
+		}
+		Expect(deviceID).To(Equal(expectedDeviceID), "resource attribute device_id mismatch")
+		Expect(orgID).ToNot(BeEmpty(), "resource attribute org_id should not be empty")
+
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				if m.GetName() != metricName {
+					continue
+				}
+				dp := m.GetSum().GetDataPoints()
+				Expect(dp).ToNot(BeEmpty())
+				attrs := dp[0].GetAttributes()
+				var dpDevice, dpOrg string
+				for _, a := range attrs {
+					switch a.Key {
+					case "device_id":
+						dpDevice = a.Value.GetStringValue()
+					case "org_id":
+						dpOrg = a.Value.GetStringValue()
+					}
+				}
+				Expect(dpDevice).To(Equal(expectedDeviceID), "data point device_id mismatch")
+				Expect(dpOrg).ToNot(BeEmpty(), "data point org_id should not be empty")
+			}
+		}
+	}
+}
 
 func createConfig(serverCrt string, serverKey string, caPath string, otlpAddr string) *config.Config {
 	config := config.NewDefault()
@@ -601,6 +1120,125 @@ func localAddr() string {
 	Expect(err).ToNot(HaveOccurred())
 	defer l.Close()
 	return l.Addr().String()
+}
+
+// ---- Mock downstream OTLP HTTP collector (TLS, no client certs) ----
+
+type httpOTLPRequest struct {
+	metrics *collectormetrics.ExportMetricsServiceRequest
+	headers http.Header
+}
+
+type mockHTTPOTLPCollector struct {
+	mu   sync.Mutex
+	reqs []httpOTLPRequest
+}
+
+func (m *mockHTTPOTLPCollector) lastRequest() *httpOTLPRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.reqs) == 0 {
+		return nil
+	}
+	return &m.reqs[len(m.reqs)-1]
+}
+
+func (m *mockHTTPOTLPCollector) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var reader io.Reader = r.Body
+	if r.Header.Get("Content-Encoding") == "gzip" {
+		gz, err := gzip.NewReader(r.Body)
+		if err != nil {
+			http.Error(w, "gzip reader", http.StatusBadRequest)
+			return
+		}
+		defer gz.Close()
+		reader = gz
+	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	var req collectormetrics.ExportMetricsServiceRequest
+	if err := proto.Unmarshal(body, &req); err != nil {
+		http.Error(w, "unmarshal proto", http.StatusBadRequest)
+		return
+	}
+
+	m.mu.Lock()
+	m.reqs = append(m.reqs, httpOTLPRequest{metrics: &req, headers: r.Header.Clone()})
+	m.mu.Unlock()
+
+	resp := &collectormetrics.ExportMetricsServiceResponse{}
+	out, _ := proto.Marshal(resp)
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}
+
+func startMockHTTPCollector(serverCert *x509.Certificate, serverKey crypto.PrivateKey) (endpoint string, stop func(), mc *mockHTTPOTLPCollector, err error) {
+	mc = &mockHTTPOTLPCollector{}
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{serverCert.Raw},
+		PrivateKey:  serverKey,
+	}
+	tcfg := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{tlsCert},
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/v1/metrics", mc)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, nil, err
+	}
+	tlsLis := tls.NewListener(lis, tcfg)
+	_, portStr, _ := net.SplitHostPort(lis.Addr().String())
+	endpoint = fmt.Sprintf("https://localhost:%s", portStr)
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() { _ = srv.Serve(tlsLis) }()
+	stop = func() {
+		_ = srv.Close()
+	}
+	return endpoint, stop, mc, nil
+}
+
+func startMockHTTPCollectorWithClientAuth(serverCert *x509.Certificate, serverKey crypto.PrivateKey, clientCAPool *x509.CertPool) (endpoint string, stop func(), mc *mockHTTPOTLPCollector, err error) {
+	mc = &mockHTTPOTLPCollector{}
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{serverCert.Raw},
+		PrivateKey:  serverKey,
+	}
+	tcfg := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{tlsCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAPool,
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/v1/metrics", mc)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", nil, nil, err
+	}
+	tlsLis := tls.NewListener(lis, tcfg)
+	_, portStr, _ := net.SplitHostPort(lis.Addr().String())
+	endpoint = fmt.Sprintf("https://localhost:%s", portStr)
+
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() { _ = srv.Serve(tlsLis) }()
+	stop = func() {
+		_ = srv.Close()
+	}
+	return endpoint, stop, mc, nil
 }
 
 // ---- Mock downstream OTLP gRPC collector (TLS + mTLS) ----


### PR DESCRIPTION
## Summary
- Add OTLP/HTTP transport selection based on endpoint URL scheme (`http://`/`https://` → otlphttp, bare `host:port` → otlp gRPC)
- Add custom header injection with `${VAR}` references expanded by the OTel confmap resolver via a strict envprovider that fails on undefined variables
- Extend Helm and Podman deployment templates with `extraEnvs`, `extraVolumeMounts`, `extraVolumes`, and Podman `Secret=` for secure secret and TLS material delivery

## Test plan
- [ ] Unit tests pass: `make unit-test RACE=0 COVERAGE=0`
- [ ] Lint passes: `make lint`
- [ ] Helm lint passes with default and Dynatrace overlay values
- [ ] Existing gRPC forwarding unchanged (backward compatibility)

Assisted-by: Claude <noreply@anthropic.com>