### PR TITLE
EDM-4858: Keep version check focused on client server

### DIFF
--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -523,7 +523,6 @@ var _ = Describe("cli operation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(clientVersion).ToNot(BeEmpty(), "client version should be found")
 			Expect(serverVersion).ToNot(BeEmpty(), "server version should be found")
-			Expect(agentVersion).To(BeEmpty(), "agent version lookup should be skipped when the VM is not initialized")
 
 			GinkgoWriter.Printf("Client version: %s\n", clientVersion)
 			GinkgoWriter.Printf("Server version: %s\n", serverVersion)


### PR DESCRIPTION
## Summary
Keep the 79621 version test focused on client/server matching and stop requiring the agent version to be empty.

the [backport](https://github.com/flightctl/flightctl/pull/3445) changed the test from agent == server to client == server, but also added the wrong 'agent must be empty assumption'. Our new PR removes only that bad assumption.

Previous [PR](https://github.com/flightctl/flightctl/pull/3445) fixed the real version mismatch, but added one wrong assumption: that the agent version should always be empty in this test.
That worked in runs without a VM, but ACM-D sets up a VM before the CLI test, so flightctl version correctly returns an agent version and the test fails even though client/server match.
This PR keeps the test focused on its actual purpose: verify client and server versions match, while logging the agent version only for diagnostics



## Why
The release-1.2 backport got the version-test fix, but release-1.2 does not have [the newer VM-removal change](https://github.com/flightctl/flightctl/pull/3247). So in ACM-D release-1.2, the CLI suite still initializes a VM, and flightctl version returns an agent version.
That made the “agent version should be empty” assertion wrong for release-1.2. The new PR fixes that by keeping the test only about client/server matching.
