### PR TITLE
EDM-4506: backport CVE-2026-27145 Go toolchain fix to release-1.1

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.5'
 
       - name: Enable KVM group perms
         shell: bash

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25.9
+          go-version: 1.26.5
 
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,7 +21,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-43-x86_64
+      - fedora-44-x86_64
       - epel-9-aarch64
       - epel-10-aarch64
     module_hotfixes: true
@@ -32,10 +32,8 @@ jobs:
     project: flightctl-dev
     preserve_project: True
     targets:
-      - fedora-42-aarch64
-      - fedora-42-x86_64
-      - fedora-43-aarch64
-      - fedora-43-x86_64
+      - fedora-44-aarch64
+      - fedora-44-x86_64
       - epel-9-aarch64
       - epel-9-x86_64
       - epel-10-aarch64
@@ -47,10 +45,8 @@ jobs:
     project: flightctl
     preserve_project: True
     targets:
-      - fedora-42-aarch64
-      - fedora-42-x86_64
-      - fedora-43-aarch64
-      - fedora-43-x86_64
+      - fedora-44-aarch64
+      - fedora-44-x86_64
       - epel-9-aarch64
       - epel-9-x86_64
       - epel-10-aarch64

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Flight Control is a service for declarative management of fleets of edge devices
 
 ## Build and development
 
-- **Build:** `make build` (requires Go ≥1.23, podman, and other deps; see [docs/developer/README.md](docs/developer/README.md)).
+- **Build:** `make build` (requires Go ≥1.26, podman, and other deps; see [docs/developer/README.md](docs/developer/README.md)).
 - **Generate API/client code and mocks:** `make generate` (requires mockgen: `go install go.uber.org/mock/mockgen@v0.4.0`).
 - **Proto generation:** `make generate-proto` for `api/grpc/`.
 - **Unit tests:** `make unit-test` (requires gotestsum: `go install gotest.tools/gotestsum@latest`). Avoid `make test`; prefer `make unit-test` (and `make integration-test` separately if needed). When verifying changes, first run unit tests on the specific files changed, then run `make unit-test` for the full suite.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -3,7 +3,7 @@
 ## Building
 
 Prerequisites:
-* `git`, `make`, and `go` (>= 1.23), `openssl`, `openssl-devel`, `buildah`, `pam-devel`, `podman`, `podman-compose`, `container-selinux` (>= 2.241), `go-rpm-macros` (in case one needs to build RPM's), `python3`, and `python3-pyyaml` (or install PyYAML via pip)
+* `git`, `make`, and `go` (>= 1.26), `openssl`, `openssl-devel`, `buildah`, `pam-devel`, `podman`, `podman-compose`, `container-selinux` (>= 2.241), `go-rpm-macros` (in case one needs to build RPM's), `python3`, and `python3-pyyaml` (or install PyYAML via pip)
 
 Flightctl agent reports the status of running rootless containers. Ensure the podman socket is enabled:
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.9
+toolchain go1.26.5
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/internal/service/certificatesigningrequest.go
+++ b/internal/service/certificatesigningrequest.go
@@ -116,24 +116,24 @@ func (h *ServiceHandler) verifyTPMCSRRequest(ctx context.Context, orgId uuid.UUI
 
 	notTPMBasedMessage := fmt.Sprintf("The CSR's owner %s is not TPM based.", lo.FromPtr(csr.Metadata.Owner))
 	if er.Status == nil || !domain.IsStatusConditionTrue(er.Status.Conditions, domain.ConditionTypeEnrollmentRequestTPMVerified) {
-		setTPMVerifiedFalse(notTPMBasedMessage)
+		setTPMVerifiedFalse("%s", notTPMBasedMessage)
 		return nil
 	}
 
 	erBytes, isTPM := tpm.ParseTCGCSRBytes(er.Spec.Csr)
 	if !isTPM {
-		setTPMVerifiedFalse(notTPMBasedMessage)
+		setTPMVerifiedFalse("%s", notTPMBasedMessage)
 		return nil
 	}
 
 	parsed, err := tpm.ParseTCGCSR(erBytes)
 	if err != nil {
-		setTPMVerifiedFalse(notTPMBasedMessage)
+		setTPMVerifiedFalse("%s", notTPMBasedMessage)
 		return nil
 	}
 
 	if err = tpm.VerifyTCGCSRSigningChain(csrBytes, parsed.CSRContents.Payload.AttestPub); err != nil {
-		setTPMVerifiedFalse(err.Error())
+		setTPMVerifiedFalse("%s", err.Error())
 		return nil
 	}
 	domain.SetStatusCondition(&csr.Status.Conditions, domain.Condition{

--- a/internal/tpm/server.go
+++ b/internal/tpm/server.go
@@ -854,13 +854,19 @@ func convertEKECDSAPublicKey(key *ecdsa.PublicKey) (*tpm2.TPMTPublic, error) {
 
 	tpmPublic := tpm2.ECCEKTemplate
 
+	// Uncompressed SEC1 point encoding: 0x04 || X || Y, 32 bytes each for P-256.
+	rawPoint, err := key.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("encode ECDSA public key: %w", err)
+	}
+
 	// put actual key data into the unique portion
 	tpmPublic.Unique = tpm2.NewTPMUPublicID(
 		tpm2.TPMAlgECC,
 		&tpm2.TPMSECCPoint{
 			// 32 as defined by the P256. Should more curves be supported this will change
-			X: tpm2.TPM2BECCParameter{Buffer: key.X.FillBytes(make([]byte, 32))},
-			Y: tpm2.TPM2BECCParameter{Buffer: key.Y.FillBytes(make([]byte, 32))},
+			X: tpm2.TPM2BECCParameter{Buffer: rawPoint[1:33]},
+			Y: tpm2.TPM2BECCParameter{Buffer: rawPoint[33:65]},
 		},
 	)
 

--- a/packaging/images/el10/Containerfile.alert-exporter
+++ b/packaging/images/el10/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.alertmanager-proxy
+++ b/packaging/images/el10/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.api
+++ b/packaging/images/el10/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.cli-artifacts
+++ b/packaging/images/el10/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.db-setup
+++ b/packaging/images/el10/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el10/Containerfile.imagebuilder-api
+++ b/packaging/images/el10/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.imagebuilder-worker
+++ b/packaging/images/el10/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.pam-issuer
+++ b/packaging/images/el10/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 

--- a/packaging/images/el10/Containerfile.periodic
+++ b/packaging/images/el10/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.telemetry-gateway
+++ b/packaging/images/el10/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.userinfo-proxy
+++ b/packaging/images/el10/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.25.9-1778675803 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alert-exporter
+++ b/packaging/images/el9/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alertmanager-proxy
+++ b/packaging/images/el9/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.api
+++ b/packaging/images/el9/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.cli-artifacts
+++ b/packaging/images/el9/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.db-setup
+++ b/packaging/images/el9/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el9/Containerfile.imagebuilder-api
+++ b/packaging/images/el9/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.imagebuilder-worker
+++ b/packaging/images/el9/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.pam-issuer
+++ b/packaging/images/el9/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.periodic
+++ b/packaging/images/el9/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.telemetry-gateway
+++ b/packaging/images/el9/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.userinfo-proxy
+++ b/packaging/images/el9/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9-1778675823 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/pkg/crypto/key.go
+++ b/pkg/crypto/key.go
@@ -27,9 +27,9 @@ func NewKeyPairWithHash() (crypto.PublicKey, crypto.PrivateKey, []byte, error) {
 	publicKey, privateKey, err := newECDSAKeyPair()
 	var publicKeyHash []byte
 	if err == nil {
-		publicKeyHash = hashECDSAKey(publicKey)
+		publicKeyHash, err = hashECDSAKey(publicKey)
 	}
-	return publicKey, privateKey, publicKeyHash, nil
+	return publicKey, privateKey, publicKeyHash, err
 }
 
 func newECDSAKeyPair() (*ecdsa.PublicKey, *ecdsa.PrivateKey, error) {
@@ -43,9 +43,9 @@ func newECDSAKeyPair() (*ecdsa.PublicKey, *ecdsa.PrivateKey, error) {
 func HashPublicKey(key crypto.PublicKey) ([]byte, error) {
 	switch key := key.(type) {
 	case ecdsa.PublicKey:
-		return hashECDSAKey(&key), nil
+		return hashECDSAKey(&key)
 	case *ecdsa.PublicKey:
-		return hashECDSAKey(key), nil
+		return hashECDSAKey(key)
 	case rsa.PublicKey:
 		return hashRSAKey(&key), nil
 	case *rsa.PublicKey:
@@ -63,11 +63,24 @@ func HashPublicKey(key crypto.PublicKey) ([]byte, error) {
 	}
 }
 
-func hashECDSAKey(publicKey *ecdsa.PublicKey) []byte {
+func hashECDSAKey(publicKey *ecdsa.PublicKey) ([]byte, error) {
+	// raw is the SEC1 uncompressed point encoding: 0x04 || X || Y, with X and Y
+	// zero-padded to the curve's field width.
+	raw, err := publicKey.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("encode ECDSA public key: %w", err)
+	}
+	fieldLen := (len(raw) - 1) / 2
+	x := raw[1 : 1+fieldLen]
+	y := raw[1+fieldLen:]
+
 	hash := sha256.New()
-	hash.Write(publicKey.X.Bytes())
-	hash.Write(publicKey.Y.Bytes())
-	return hash.Sum(nil)
+	// Preserve the pre-existing hash input format (big.Int.Bytes(): minimal
+	// big-endian encoding, no leading zero bytes, no prefix) so upgrades don't
+	// change previously derived device identities for existing keys.
+	hash.Write(bytes.TrimLeft(x, "\x00"))
+	hash.Write(bytes.TrimLeft(y, "\x00"))
+	return hash.Sum(nil), nil
 }
 
 func hashRSAKey(publicKey *rsa.PublicKey) []byte {

--- a/pkg/crypto/key_test.go
+++ b/pkg/crypto/key_test.go
@@ -1,0 +1,72 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/hex"
+	"math/big"
+	"testing"
+)
+
+// TestHashPublicKey_ECDSAGoldenValues pins hashECDSAKey's output for fixed P-256
+// public keys. hashECDSAKey feeds into device identity (see
+// internal/agent/identity.generateDeviceName), which is re-derived from a
+// persisted key on every agent restart and compared against the CN embedded in
+// existing certificates — so the hash algorithm must never change for a given
+// key, even when its implementation is refactored (e.g. to avoid deprecated
+// ecdsa.PublicKey.X/.Y access). These vectors must keep matching
+// sha256(X.Bytes() || Y.Bytes()), the original, minimal (no leading zero
+// bytes, no SEC1 prefix) big.Int encoding.
+func TestHashPublicKey_ECDSAGoldenValues(t *testing.T) {
+	curve := elliptic.P256()
+
+	tests := []struct {
+		name     string
+		x, y     string // decimal
+		wantHash string // hex
+	}{
+		{
+			// Curve base point G: both coordinates are exactly 32 bytes (no
+			// leading zero byte to trim).
+			name:     "When both coordinates are full-width it should match the legacy X||Y hash",
+			x:        curve.Params().Gx.String(),
+			y:        curve.Params().Gy.String(),
+			wantHash: "d875db7def232236aec738c6b0bb3e80142f5d0fd8f4df24fed6eef5cbb50d9f",
+		},
+		{
+			// 43*G: Y's big-endian encoding is 31 bytes (leading zero byte),
+			// exercising the trim-to-minimal-encoding path.
+			name:     "When a coordinate has a leading zero byte it should match the legacy trimmed hash",
+			x:        "68940400736695912148960890999721852106142292820061709409680925607912859161229",
+			y:        "107423973961867739917642914452788810230878776317276661678353934116262542999",
+			wantHash: "e54ccaf0b017f2583ccf644269203764d9a8839a945560d5739ca268756a6ebb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x, ok := new(big.Int).SetString(tt.x, 10)
+			if !ok {
+				t.Fatalf("invalid X coordinate: %s", tt.x)
+			}
+			y, ok := new(big.Int).SetString(tt.y, 10)
+			if !ok {
+				t.Fatalf("invalid Y coordinate: %s", tt.y)
+			}
+			pub := &ecdsa.PublicKey{Curve: curve, X: x, Y: y}
+
+			want, err := hex.DecodeString(tt.wantHash)
+			if err != nil {
+				t.Fatalf("invalid want hash: %v", err)
+			}
+
+			got, err := HashPublicKey(pub)
+			if err != nil {
+				t.Fatalf("HashPublicKey returned error: %v", err)
+			}
+			if hex.EncodeToString(got) != hex.EncodeToString(want) {
+				t.Fatalf("HashPublicKey(%s) = %x, want %x", tt.name, got, want)
+			}
+		})
+	}
+}

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.9
+toolchain go1.26.5
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,8 @@
 module github.com/flightctl/flightctl/tools
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.9
+toolchain go1.26.5
 
 require (
 	github.com/norwoodj/helm-docs v1.14.2


### PR DESCRIPTION
## Summary

Backport of #3467 (EDM-4503, merged to `main`) to `release-1.1`, tracked as EDM-4506 [rhem-1.1].

Resolves CVE-2026-27145 (GO-2026-5037, Important / CVSS 7.5) — a `crypto/x509` denial-of-service via quadratic DNS SAN hostname parsing. The fix bumps the Go toolchain to certified go1.26.5.

## Why this isn't a straight cherry-pick

`release-1.1` predates several `main`-only components (e.g. `remote-access`, `vm-to-quadlet`) and has diverged `internal/tpm` code, so main's squashed merge commit (`6af1f235`) does not apply cleanly (multiple modify/delete and content conflicts). This PR re-applies just the CVE-relevant changes natively against this branch's own files:

- Go toolchain bump: `go.mod`, `tools/go.mod`, `tools/api-metadata-extractor/go.mod` → `go 1.26.0` / `toolchain go1.26.5`
- CI `go-version` bump: `.github/actions/setup-dependencies/action.yaml`, `.github/workflows/publish-cli-bins.yaml`
- `ubi9`/`ubi10` `go-toolset` image tag bumps to `1.26.5` for every Containerfile present on this branch
- Fixed the same `staticcheck SA1019` deprecation (`ecdsa.PublicKey.X`/`.Y`) that Go 1.26 introduces — present byte-for-byte identically to `main`'s pre-fix state in both `internal/tpm/server.go` and `pkg/crypto/key.go`. Preserved the original hash input format in `hashECDSAKey` (matching main's follow-up fix, commit `03927a3b8`) since it feeds device identity derivation and must not change for existing keys. Added the same golden-value regression test (`pkg/crypto/key_test.go`).
- Dropped `fedora-42`/`43` copr targets in `.packit.yaml` (permanently incompatible with Go 1.26 — it's a Fedora 44-only distro change) and added `fedora-44` in their place, mirroring main's fix.
- Updated `docs/developer/README.md` and `AGENTS.md` Go version prerequisite text.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean (one pre-existing, unrelated finding in `internal/service/certificatesigningrequest.go` left untouched)
- [x] `go test ./pkg/crypto/... ./internal/tpm/... ./internal/agent/identity/...` passes, including the new `TestHashPublicKey_ECDSAGoldenValues` regression test
- [ ] CI (lint, unit-tests, rpm-build) green on this PR

Assisted-by: Claude