### PR TITLE
EDM-3773: Preserve prefetch errors across OS rollback status

### DIFF
--- a/internal/agent/device/bootstrap.go
+++ b/internal/agent/device/bootstrap.go
@@ -173,8 +173,24 @@ func (b *Bootstrap) updateStatus(ctx context.Context) {
 		// TODO: only set rebooting in case where we are actually rebooting
 		updatingCondition.Reason = string(v1beta1.UpdateStateRebooting)
 	} else {
-		updatingCondition.Status = v1beta1.ConditionStatusFalse
-		updatingCondition.Reason = string(v1beta1.UpdateStateUpdated)
+		rollbackInfo, err := b.specManager.GetRollbackInfo()
+		if err != nil {
+			b.log.Errorf("Failed to read rollback info: %v", err)
+			updatingCondition.Status = v1beta1.ConditionStatusFalse
+			updatingCondition.Reason = string(v1beta1.UpdateStateError)
+			updatingCondition.Message = "Failed to read rollback info after update"
+		} else if rollbackInfo.ErrorMessage != "" || rollbackInfo.Version != "" {
+			updatingCondition.Status = v1beta1.ConditionStatusFalse
+			updatingCondition.Reason = string(v1beta1.UpdateStateError)
+			if rollbackInfo.ErrorMessage != "" {
+				updatingCondition.Message = rollbackInfo.ErrorMessage
+			} else {
+				updatingCondition.Message = fmt.Sprintf("Failed to update to renderedVersion: %s", rollbackInfo.Version)
+			}
+		} else {
+			updatingCondition.Status = v1beta1.ConditionStatusFalse
+			updatingCondition.Reason = string(v1beta1.UpdateStateUpdated)
+		}
 	}
 
 	_, updateErr := b.statusManager.Update(ctx,

--- a/internal/agent/device/bootstrap_test.go
+++ b/internal/agent/device/bootstrap_test.go
@@ -71,6 +71,7 @@ func TestInitialization(t *testing.T) {
 					mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{}, nil),
 					mockSystemInfoManager.EXPECT().IsRebooted().Return(false),
 					mockSpecManager.EXPECT().IsUpgrading().Return(false),
+					mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{}, nil),
 					mockSpecManager.EXPECT().RenderedVersion(spec.Current).Return("1"),
 					mockStatusManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil),
 				)
@@ -135,6 +136,7 @@ func TestInitialization(t *testing.T) {
 					mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{}, nil),
 					mockSystemInfoManager.EXPECT().IsRebooted().Return(false),
 					mockSpecManager.EXPECT().IsUpgrading().Return(false),
+					mockSpecManager.EXPECT().GetRollbackInfo().Return(spec.RollbackInfo{}, nil),
 					mockSpecManager.EXPECT().RenderedVersion(spec.Current).Return("2"),
 					mockStatusManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil),
 				)
@@ -194,6 +196,98 @@ func TestInitialization(t *testing.T) {
 				return
 			}
 			require.NoError(err)
+		})
+	}
+}
+
+func TestUpdateStatus(t *testing.T) {
+	require := require.New(t)
+	ctx := context.TODO()
+
+	testCases := []struct {
+		name           string
+		upgrading      bool
+		rollbackInfo   spec.RollbackInfo
+		rollbackErr    error
+		wantReason     string
+		wantMessage    string
+		wantMsgContain string
+	}{
+		{
+			name:       "When upgrading it should report Rebooting",
+			upgrading:  true,
+			wantReason: string(v1beta1.UpdateStateRebooting),
+		},
+		{
+			name:       "When not upgrading and no rollback info it should report Updated",
+			wantReason: string(v1beta1.UpdateStateUpdated),
+		},
+		{
+			name: "When rollback info has a persisted error it should report Error with that message",
+			rollbackInfo: spec.RollbackInfo{
+				Version:      "6",
+				SpecHash:     "abc123",
+				ErrorMessage: "[2026-04-23 12:00:00] While Preparing: prefetch failed for quay.io/flightctl/images:doesnotexist: required resource not found",
+			},
+			wantReason:     string(v1beta1.UpdateStateError),
+			wantMsgContain: "prefetch failed for quay.io/flightctl/images:doesnotexist",
+		},
+		{
+			name:         "When rollback info has a version but no error it should report Error for that version",
+			rollbackInfo: spec.RollbackInfo{Version: "6", SpecHash: "abc123"},
+			wantReason:   string(v1beta1.UpdateStateError),
+			wantMessage:  "Failed to update to renderedVersion: 6",
+		},
+		{
+			name:        "When rollback info cannot be read it should not report Updated",
+			rollbackErr: errors.New("disk error"),
+			wantReason:  string(v1beta1.UpdateStateError),
+			wantMessage: "Failed to read rollback info after update",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStatusManager := status.NewMockManager(ctrl)
+			mockSpecManager := spec.NewMockManager(ctrl)
+
+			mockSpecManager.EXPECT().IsUpgrading().Return(tt.upgrading)
+			if !tt.upgrading {
+				mockSpecManager.EXPECT().GetRollbackInfo().Return(tt.rollbackInfo, tt.rollbackErr)
+			}
+			mockSpecManager.EXPECT().RenderedVersion(spec.Current).Return("1")
+
+			var gotCondition v1beta1.Condition
+			mockStatusManager.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, fns ...status.UpdateStatusFn) (*v1beta1.DeviceStatus, error) {
+					ds := &v1beta1.DeviceStatus{}
+					for _, fn := range fns {
+						require.NoError(fn(ds))
+					}
+					cond := v1beta1.FindStatusCondition(ds.Conditions, v1beta1.ConditionTypeDeviceUpdating)
+					require.NotNil(cond)
+					gotCondition = *cond
+					return ds, nil
+				},
+			)
+
+			b := &Bootstrap{
+				statusManager: mockStatusManager,
+				specManager:   mockSpecManager,
+				log:           log.NewPrefixLogger("test"),
+			}
+			b.updateStatus(ctx)
+
+			require.Equal(tt.wantReason, gotCondition.Reason)
+			if tt.wantMessage != "" {
+				require.Equal(tt.wantMessage, gotCondition.Message)
+			}
+			if tt.wantMsgContain != "" {
+				require.Contains(gotCondition.Message, tt.wantMsgContain)
+			}
 		})
 	}
 }

--- a/internal/agent/device/bootstrap_test.go
+++ b/internal/agent/device/bootstrap_test.go
@@ -202,7 +202,8 @@ func TestInitialization(t *testing.T) {
 
 func TestUpdateStatus(t *testing.T) {
 	require := require.New(t)
-	ctx := context.TODO()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	testCases := []struct {
 		name           string

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -353,7 +353,7 @@ func (a *Agent) rollbackDevice(ctx context.Context, current, desired *v1beta1.De
 		}
 		syncMsg := formatSyncErrorMessage(desired, syncErr)
 		a.handleSyncError(ctx, desired, syncErr)
-		if err := a.specManager.RecordRollbackError(syncMsg); err != nil {
+		if err := a.specManager.RecordRollbackError(ctx, syncMsg); err != nil {
 			a.log.Errorf("Failed to persist rollback error: %v", err)
 		}
 

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -351,13 +351,17 @@ func (a *Agent) rollbackDevice(ctx context.Context, current, desired *v1beta1.De
 		if err := syncFn(ctx, desired, current); err != nil {
 			a.log.Warnf("Rollback sync completed with errors, proceeding with OS rollback: %v", err)
 		}
+		syncMsg := formatSyncErrorMessage(desired, syncErr)
 		a.handleSyncError(ctx, desired, syncErr)
+		if err := a.specManager.RecordRollbackError(syncMsg); err != nil {
+			a.log.Errorf("Failed to persist rollback error: %v", err)
+		}
 
 		rollbackDevice, err := a.specManager.Read(spec.Rollback)
 		if err != nil {
 			return fmt.Errorf("reading rollback spec for OS rollback: %w", err)
 		}
-		return a.rebootIntoRollbackOS(ctx, rollbackDevice.Spec)
+		return a.rebootIntoRollbackOS(ctx, rollbackDevice.Spec, syncMsg)
 	}
 
 	if err := a.specManager.Rollback(ctx); err != nil {
@@ -367,13 +371,17 @@ func (a *Agent) rollbackDevice(ctx context.Context, current, desired *v1beta1.De
 	return syncFn(ctx, desired, current)
 }
 
-func (a *Agent) rebootIntoRollbackOS(ctx context.Context, rollbackSpec *v1beta1.DeviceSpec) error {
+func (a *Agent) rebootIntoRollbackOS(ctx context.Context, rollbackSpec *v1beta1.DeviceSpec, syncMsg string) error {
 	if err := a.hookManager.OnBeforeRebooting(ctx); err != nil {
 		a.log.Errorf("Error executing BeforeRebooting hook: %v", err)
 		return err
 	}
 
 	infoMsg := fmt.Sprintf("Device is rebooting into rollback OS: %s", rollbackSpec.Os.Image)
+	if syncMsg != "" {
+		infoMsg = fmt.Sprintf("%s: %s", infoMsg, syncMsg)
+	}
+	infoMsg = log.Truncate(infoMsg, status.MaxMessageLength)
 	_, updateErr := a.statusManager.Update(ctx, status.SetDeviceSummary(v1beta1.DeviceSummaryStatus{
 		Status: v1beta1.DeviceSummaryStatusRebooting,
 		Info:   lo.ToPtr(infoMsg),
@@ -690,9 +698,9 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 
 	se := errors.FormatError(syncErr)
 	if !errors.IsRetryable(syncErr) {
-		msg := fmt.Sprintf("Failed to update to renderedVersion: %s: %v", version, syncErr.Error())
+		msg := formatSyncErrorMessage(desired, syncErr)
 		conditionUpdate.Reason = string(v1beta1.UpdateStateError)
-		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
+		conditionUpdate.Message = msg
 		conditionUpdate.Status = v1beta1.ConditionStatusFalse
 		a.pullConfigResolver.Cleanup()
 		a.prefetchManager.Cleanup()
@@ -703,13 +711,22 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
 		conditionUpdate.Status = v1beta1.ConditionStatusTrue
 		a.log.Warn(msg, se.Timestamp)
-	}
-	if se.Phase != nil || se.Component != nil {
-		conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
+		if se.Phase != nil || se.Component != nil {
+			conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
+		}
 	}
 	if err := a.statusManager.UpdateCondition(ctx, conditionUpdate); err != nil {
 		a.log.Warnf("Failed to update device status condition: %v", err)
 	}
+}
+
+func formatSyncErrorMessage(desired *v1beta1.Device, syncErr error) string {
+	se := errors.FormatError(syncErr)
+	msg := fmt.Sprintf("Failed to update to renderedVersion: %s: %v", desired.Version(), syncErr.Error())
+	if se.Phase != nil || se.Component != nil {
+		msg = se.Message()
+	}
+	return log.Truncate(msg, status.MaxMessageLength)
 }
 
 func (a *Agent) handlePrefetchNotReady(ctx context.Context, syncErr error) {

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -698,9 +698,9 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 
 	se := errors.FormatError(syncErr)
 	if !errors.IsRetryable(syncErr) {
-		msg := formatSyncErrorMessage(desired, syncErr)
+		msg := fmt.Sprintf("Failed to update to renderedVersion: %s: %v", version, syncErr.Error())
 		conditionUpdate.Reason = string(v1beta1.UpdateStateError)
-		conditionUpdate.Message = msg
+		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
 		conditionUpdate.Status = v1beta1.ConditionStatusFalse
 		a.pullConfigResolver.Cleanup()
 		a.prefetchManager.Cleanup()
@@ -711,9 +711,9 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
 		conditionUpdate.Status = v1beta1.ConditionStatusTrue
 		a.log.Warn(msg, se.Timestamp)
-		if se.Phase != nil || se.Component != nil {
-			conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
-		}
+	}
+	if se.Phase != nil || se.Component != nil {
+		conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
 	}
 	if err := a.statusManager.UpdateCondition(ctx, conditionUpdate); err != nil {
 		a.log.Warnf("Failed to update device status condition: %v", err)

--- a/internal/agent/device/device.go
+++ b/internal/agent/device/device.go
@@ -353,6 +353,7 @@ func (a *Agent) rollbackDevice(ctx context.Context, current, desired *v1beta1.De
 		}
 		syncMsg := formatSyncErrorMessage(desired, syncErr)
 		a.handleSyncError(ctx, desired, syncErr)
+		// Persisting the error is best-effort and must not prevent rebooting into the rollback OS.
 		if err := a.specManager.RecordRollbackError(ctx, syncMsg); err != nil {
 			a.log.Errorf("Failed to persist rollback error: %v", err)
 		}
@@ -700,7 +701,7 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 	if !errors.IsRetryable(syncErr) {
 		msg := fmt.Sprintf("Failed to update to renderedVersion: %s: %v", version, syncErr.Error())
 		conditionUpdate.Reason = string(v1beta1.UpdateStateError)
-		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
+		conditionUpdate.Message = formatSyncErrorMessage(desired, syncErr)
 		conditionUpdate.Status = v1beta1.ConditionStatusFalse
 		a.pullConfigResolver.Cleanup()
 		a.prefetchManager.Cleanup()
@@ -711,9 +712,9 @@ func (a *Agent) handleSyncError(ctx context.Context, desired *v1beta1.Device, sy
 		conditionUpdate.Message = log.Truncate(msg, status.MaxMessageLength)
 		conditionUpdate.Status = v1beta1.ConditionStatusTrue
 		a.log.Warn(msg, se.Timestamp)
-	}
-	if se.Phase != nil || se.Component != nil {
-		conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
+		if se.Phase != nil || se.Component != nil {
+			conditionUpdate.Message = log.Truncate(se.Message(), status.MaxMessageLength)
+		}
 	}
 	if err := a.statusManager.UpdateCondition(ctx, conditionUpdate); err != nil {
 		a.log.Warnf("Failed to update device status condition: %v", err)

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -669,6 +669,28 @@ func TestOSRollback(t *testing.T) {
 			wantReboot: true,
 		},
 		{
+			name:    "When persisting the rollback error fails it should still reboot",
+			current: newVersionedDeviceWithOS("5", "quay.io/org/os:v1"),
+			desired: newVersionedDeviceWithOS("6", "quay.io/org/os:v2"),
+			setupMocks: func(
+				mockSpecManager *spec.MockManager,
+				mockManagementClient *client.MockManagement,
+				mockHookManager *hook.MockManager,
+				mockOSManager *os.MockManager,
+			) {
+				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
+				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
+				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v2", true, nil)
+				mockSpecManager.EXPECT().RecordRollbackError(gomock.Any(), gomock.Any()).Return(errors.New("write error"))
+				mockSpecManager.EXPECT().Read(spec.Rollback).Return(&v1beta1.Device{
+					Spec: &v1beta1.DeviceSpec{Os: &v1beta1.DeviceOsSpec{Image: "quay.io/org/os:v1"}},
+				}, nil)
+				mockHookManager.EXPECT().OnBeforeRebooting(gomock.Any()).Return(nil)
+				mockOSManager.EXPECT().Rollback(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantReboot: true,
+		},
+		{
 			name:    "When OS is not reconciled it should not trigger OS rollback",
 			current: newVersionedDeviceWithOS("5", "quay.io/org/os:v1"),
 			desired: newVersionedDeviceWithOS("6", "quay.io/org/os:v2"),

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -636,7 +636,7 @@ func TestOSRollback(t *testing.T) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
 				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v2", true, nil)
-				mockSpecManager.EXPECT().RecordRollbackError(gomock.Any()).Return(nil)
+				mockSpecManager.EXPECT().RecordRollbackError(gomock.Any(), gomock.Any()).Return(nil)
 				mockSpecManager.EXPECT().Read(spec.Rollback).Return(&v1beta1.Device{
 					Spec: &v1beta1.DeviceSpec{Os: &v1beta1.DeviceOsSpec{Image: "quay.io/org/os:v1"}},
 				}, nil)
@@ -659,7 +659,7 @@ func TestOSRollback(t *testing.T) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
 				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v2", true, nil)
-				mockSpecManager.EXPECT().RecordRollbackError(gomock.Any()).Return(nil)
+				mockSpecManager.EXPECT().RecordRollbackError(gomock.Any(), gomock.Any()).Return(nil)
 				mockSpecManager.EXPECT().Read(spec.Rollback).Return(&v1beta1.Device{
 					Spec: &v1beta1.DeviceSpec{Os: &v1beta1.DeviceOsSpec{Image: "quay.io/org/os:v1"}},
 				}, nil)

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -636,6 +636,7 @@ func TestOSRollback(t *testing.T) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
 				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v2", true, nil)
+				mockSpecManager.EXPECT().RecordRollbackError(gomock.Any()).Return(nil)
 				mockSpecManager.EXPECT().Read(spec.Rollback).Return(&v1beta1.Device{
 					Spec: &v1beta1.DeviceSpec{Os: &v1beta1.DeviceOsSpec{Image: "quay.io/org/os:v1"}},
 				}, nil)
@@ -658,6 +659,7 @@ func TestOSRollback(t *testing.T) {
 				mockManagementClient.EXPECT().UpdateDeviceStatus(gomock.Any(), deviceName, gomock.Any()).Return(nil).AnyTimes()
 				mockSpecManager.EXPECT().ShouldApplyOSImageUpdate().Return(true)
 				mockSpecManager.EXPECT().CheckOsReconciliation(gomock.Any()).Return("quay.io/org/os:v2", true, nil)
+				mockSpecManager.EXPECT().RecordRollbackError(gomock.Any()).Return(nil)
 				mockSpecManager.EXPECT().Read(spec.Rollback).Return(&v1beta1.Device{
 					Spec: &v1beta1.DeviceSpec{Os: &v1beta1.DeviceOsSpec{Image: "quay.io/org/os:v1"}},
 				}, nil)

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -361,7 +361,7 @@ func (s *manager) GetRollbackInfo() (RollbackInfo, error) {
 	}, nil
 }
 
-func (s *manager) RecordRollbackError(message string) error {
+func (s *manager) RecordRollbackError(ctx context.Context, message string) error {
 	if message == "" {
 		return nil
 	}
@@ -376,7 +376,7 @@ func (s *manager) RecordRollbackError(message string) error {
 		annotations = rollback.Metadata.Annotations
 	}
 	(*annotations)[annotationRollbackError] = message
-	if err := s.write(context.TODO(), Rollback, rollback, audit.ReasonRollback); err != nil {
+	if err := s.write(ctx, Rollback, rollback, audit.ReasonRollback); err != nil {
 		return fmt.Errorf("writing rollback error: %w", err)
 	}
 	return nil

--- a/internal/agent/device/spec/manager.go
+++ b/internal/agent/device/spec/manager.go
@@ -29,6 +29,9 @@ const (
 	// If a rollback occurs, this spec hash is marked as failed to prevent
 	// re-applying the same spec content even if the rendered version changes.
 	annotationDesiredSpecHash = "agent/desiredSpecHash"
+	// annotationRollbackError stores the formatted sync error that triggered
+	// an OS rollback so it can be reported after reboot.
+	annotationRollbackError = "agent/rollbackError"
 )
 
 // manager is responsible for managing the rendered device spec.
@@ -347,11 +350,36 @@ func (s *manager) GetRollbackInfo() (RollbackInfo, error) {
 		}
 		return RollbackInfo{}, fmt.Errorf("reading rollback spec: %w", err)
 	}
+	if rollback.Metadata.Annotations == nil {
+		return RollbackInfo{}, nil
+	}
 	annotations := *rollback.Metadata.Annotations
 	return RollbackInfo{
-		Version:  annotations[annotationDesiredVersion],
-		SpecHash: annotations[annotationDesiredSpecHash],
+		Version:      annotations[annotationDesiredVersion],
+		SpecHash:     annotations[annotationDesiredSpecHash],
+		ErrorMessage: annotations[annotationRollbackError],
 	}, nil
+}
+
+func (s *manager) RecordRollbackError(message string) error {
+	if message == "" {
+		return nil
+	}
+	rollback, err := s.Read(Rollback)
+	if err != nil {
+		return fmt.Errorf("reading rollback spec: %w", err)
+	}
+	annotations := rollback.Metadata.Annotations
+	if annotations == nil {
+		m := map[string]string{}
+		rollback.Metadata.Annotations = &m
+		annotations = rollback.Metadata.Annotations
+	}
+	(*annotations)[annotationRollbackError] = message
+	if err := s.write(context.TODO(), Rollback, rollback, audit.ReasonRollback); err != nil {
+		return fmt.Errorf("writing rollback error: %w", err)
+	}
+	return nil
 }
 
 func (s *manager) Rollback(ctx context.Context, opts ...RollbackOption) error {

--- a/internal/agent/device/spec/mock_spec.go
+++ b/internal/agent/device/spec/mock_spec.go
@@ -273,17 +273,17 @@ func (mr *MockManagerMockRecorder) Read(specType any) *gomock.Call {
 }
 
 // RecordRollbackError mocks base method.
-func (m *MockManager) RecordRollbackError(message string) error {
+func (m *MockManager) RecordRollbackError(ctx context.Context, message string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordRollbackError", message)
+	ret := m.ctrl.Call(m, "RecordRollbackError", ctx, message)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordRollbackError indicates an expected call of RecordRollbackError.
-func (mr *MockManagerMockRecorder) RecordRollbackError(message any) *gomock.Call {
+func (mr *MockManagerMockRecorder) RecordRollbackError(ctx, message any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRollbackError", reflect.TypeOf((*MockManager)(nil).RecordRollbackError), message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRollbackError", reflect.TypeOf((*MockManager)(nil).RecordRollbackError), ctx, message)
 }
 
 // RenderedVersion mocks base method.

--- a/internal/agent/device/spec/mock_spec.go
+++ b/internal/agent/device/spec/mock_spec.go
@@ -272,6 +272,20 @@ func (mr *MockManagerMockRecorder) Read(specType any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockManager)(nil).Read), specType)
 }
 
+// RecordRollbackError mocks base method.
+func (m *MockManager) RecordRollbackError(message string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecordRollbackError", message)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecordRollbackError indicates an expected call of RecordRollbackError.
+func (mr *MockManagerMockRecorder) RecordRollbackError(message any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordRollbackError", reflect.TypeOf((*MockManager)(nil).RecordRollbackError), message)
+}
+
 // RenderedVersion mocks base method.
 func (m *MockManager) RenderedVersion(specType Type) string {
 	m.ctrl.T.Helper()

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -36,12 +36,13 @@ var defaultSpecPollConfig = func() poll.Config {
 	}
 }()
 
-// RollbackInfo contains the desired version and spec hash from the rollback
-// spec. These identify the spec we were upgrading to when the rollback was
-// created.
+// RollbackInfo contains the desired version, spec hash, and optional sync error
+// from the rollback spec. These identify the spec we were upgrading to when the
+// rollback was created and, when present, the reason the update failed.
 type RollbackInfo struct {
-	Version  string
-	SpecHash string
+	Version      string
+	SpecHash     string
+	ErrorMessage string
 }
 
 // Watcher provides a way to watch for device spec updates.
@@ -90,10 +91,13 @@ type Manager interface {
 	CreateRollback(ctx context.Context) error
 	// ClearRollback clears the rollback rendered spec.
 	ClearRollback() error
-	// GetRollbackInfo returns the desired version and spec hash stored in
-	// rollback.json. These identify the spec we were upgrading to when the
-	// rollback was created.
+	// GetRollbackInfo returns the desired version, spec hash, and persisted
+	// sync error stored in rollback.json. These identify the spec we were
+	// upgrading to when the rollback was created.
 	GetRollbackInfo() (RollbackInfo, error)
+	// RecordRollbackError stores the sync error that caused a rollback in
+	// rollback.json so the message survives the rollback reboot.
+	RecordRollbackError(message string) error
 	// Rollback reverts the device to the state of the rollback rendered spec.
 	Rollback(ctx context.Context, opts ...RollbackOption) error
 	// GetDesired returns the desired rendered device from the management API.

--- a/internal/agent/device/spec/spec.go
+++ b/internal/agent/device/spec/spec.go
@@ -97,7 +97,7 @@ type Manager interface {
 	GetRollbackInfo() (RollbackInfo, error)
 	// RecordRollbackError stores the sync error that caused a rollback in
 	// rollback.json so the message survives the rollback reboot.
-	RecordRollbackError(message string) error
+	RecordRollbackError(ctx context.Context, message string) error
 	// Rollback reverts the device to the state of the rollback rendered spec.
 	Rollback(ctx context.Context, opts ...RollbackOption) error
 	// GetDesired returns the desired rendered device from the management API.

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -834,6 +834,18 @@ func TestRecordRollbackError(t *testing.T) {
 		require.NoError(err)
 	})
 
+	t.Run("When rollback spec is missing it should propagate the error", func(t *testing.T) {
+		mockReadWriter.EXPECT().ReadFile(rollbackPath).Return(nil, errors.ErrNotExist)
+		err := s.RecordRollbackError(ctx, "prefetch failed for bad-image")
+		require.ErrorIs(err, errors.ErrMissingRenderedSpec)
+	})
+
+	t.Run("When rollback spec cannot be read it should propagate the error", func(t *testing.T) {
+		mockReadWriter.EXPECT().ReadFile(rollbackPath).Return(nil, errors.New("read error"))
+		err := s.RecordRollbackError(ctx, "prefetch failed for bad-image")
+		require.ErrorIs(err, errors.ErrReadingRenderedSpec)
+	})
+
 	t.Run("When rollback spec exists it should persist the error message", func(t *testing.T) {
 		device := createTestRenderedDevice("flightctl-device:v1")
 		(*device.Metadata.Annotations)[annotationDesiredVersion] = "6"

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"testing"
 	"time"
@@ -754,6 +755,99 @@ func TestCreateRollback(t *testing.T) {
 
 		err = s.CreateRollback(ctx)
 		require.ErrorIs(err, errors.ErrGettingBootcStatus)
+	})
+}
+
+func TestGetRollbackInfo(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+	log := log.NewPrefixLogger("test")
+	rollbackPath := "test/rollback.json"
+	s := &manager{
+		log:              log,
+		deviceReadWriter: mockReadWriter,
+		rollbackPath:     rollbackPath,
+		cache:            newCache(log),
+	}
+
+	t.Run("When rollback spec is missing it should return empty info", func(t *testing.T) {
+		mockReadWriter.EXPECT().ReadFile(rollbackPath).Return(nil, errors.ErrNotExist)
+		info, err := s.GetRollbackInfo()
+		require.NoError(err)
+		require.Empty(info.Version)
+		require.Empty(info.SpecHash)
+		require.Empty(info.ErrorMessage)
+	})
+
+	t.Run("When annotations are nil it should return empty info", func(t *testing.T) {
+		device := &v1beta1.Device{
+			Metadata: v1beta1.ObjectMeta{},
+			Spec:     &v1beta1.DeviceSpec{},
+		}
+		b, err := json.Marshal(device)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(rollbackPath).Return(b, nil)
+		info, err := s.GetRollbackInfo()
+		require.NoError(err)
+		require.Empty(info.ErrorMessage)
+	})
+
+	t.Run("When error message is stored it should return it", func(t *testing.T) {
+		device := createTestRenderedDevice("flightctl-device:v1")
+		(*device.Metadata.Annotations)[annotationDesiredVersion] = "6"
+		(*device.Metadata.Annotations)[annotationDesiredSpecHash] = "abc123"
+		(*device.Metadata.Annotations)[annotationRollbackError] = "prefetch failed for quay.io/flightctl/images:doesnotexist"
+		b, err := json.Marshal(device)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(rollbackPath).Return(b, nil)
+		info, err := s.GetRollbackInfo()
+		require.NoError(err)
+		require.Equal("6", info.Version)
+		require.Equal("abc123", info.SpecHash)
+		require.Equal("prefetch failed for quay.io/flightctl/images:doesnotexist", info.ErrorMessage)
+	})
+}
+
+func TestRecordRollbackError(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadWriter := fileio.NewMockReadWriter(ctrl)
+	log := log.NewPrefixLogger("test")
+	rollbackPath := "test/rollback.json"
+	s := &manager{
+		log:              log,
+		deviceReadWriter: mockReadWriter,
+		rollbackPath:     rollbackPath,
+		cache:            newCache(log),
+	}
+
+	t.Run("When message is empty it should be a no-op", func(t *testing.T) {
+		err := s.RecordRollbackError("")
+		require.NoError(err)
+	})
+
+	t.Run("When rollback spec exists it should persist the error message", func(t *testing.T) {
+		device := createTestRenderedDevice("flightctl-device:v1")
+		(*device.Metadata.Annotations)[annotationDesiredVersion] = "6"
+		existing, err := json.Marshal(device)
+		require.NoError(err)
+		mockReadWriter.EXPECT().ReadFile(rollbackPath).Return(existing, nil)
+		mockReadWriter.EXPECT().WriteFile(rollbackPath, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ string, data []byte, _ fs.FileMode, _ ...fileio.FileOption) error {
+				var written v1beta1.Device
+				require.NoError(json.Unmarshal(data, &written))
+				require.Equal("6", (*written.Metadata.Annotations)[annotationDesiredVersion])
+				require.Equal("prefetch failed for bad-image", (*written.Metadata.Annotations)[annotationRollbackError])
+				return nil
+			},
+		)
+		err = s.RecordRollbackError("prefetch failed for bad-image")
+		require.NoError(err)
 	})
 }
 

--- a/internal/agent/device/spec/spec_test.go
+++ b/internal/agent/device/spec/spec_test.go
@@ -816,6 +816,9 @@ func TestRecordRollbackError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	mockReadWriter := fileio.NewMockReadWriter(ctrl)
 	log := log.NewPrefixLogger("test")
 	rollbackPath := "test/rollback.json"
@@ -827,7 +830,7 @@ func TestRecordRollbackError(t *testing.T) {
 	}
 
 	t.Run("When message is empty it should be a no-op", func(t *testing.T) {
-		err := s.RecordRollbackError("")
+		err := s.RecordRollbackError(ctx, "")
 		require.NoError(err)
 	})
 
@@ -846,7 +849,7 @@ func TestRecordRollbackError(t *testing.T) {
 				return nil
 			},
 		)
-		err = s.RecordRollbackError("prefetch failed for bad-image")
+		err = s.RecordRollbackError(ctx, "prefetch failed for bad-image")
 		require.NoError(err)
 	})
 }

--- a/test/harness/e2e/harness_device.go
+++ b/test/harness/e2e/harness_device.go
@@ -658,78 +658,49 @@ func (h *Harness) UpdateDeviceAndWaitForVersion(deviceID string, updateFunc func
 	return nil
 }
 
-// deviceUpdateFailedOrRolledBack is true when the device did not successfully apply the desired
-// spec. That is either a stable Updating/Error (optional message check), or a completed OS/spec
-// rollback where the agent reports Updating/Updated, summary online, and updated OutOfDate — in
-// that case the prefetch or sync error is not always preserved on the condition after rollback.
-func deviceUpdateFailedOrRolledBack(device *v1beta1.Device, expectedMessageSubstrings []string) bool {
+// deviceUpdateFailed is true when the device reports a stable Updating/Error
+// condition. If expectedMessageSubstrings are provided, the condition message
+// must contain at least one of them.
+func deviceUpdateFailed(device *v1beta1.Device, expectedMessageSubstrings []string) bool {
 	if device == nil || device.Status == nil {
 		return false
 	}
 
-	if ConditionExists(device, v1beta1.ConditionTypeDeviceUpdating,
+	if !ConditionExists(device, v1beta1.ConditionTypeDeviceUpdating,
 		v1beta1.ConditionStatusFalse, string(v1beta1.UpdateStateError)) {
-		if len(expectedMessageSubstrings) == 0 {
-			return true
-		}
-		cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceUpdating)
-		if cond == nil {
-			return false
-		}
-		for _, substring := range expectedMessageSubstrings {
-			if strings.Contains(cond.Message, substring) {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Rollback: bootc/OS rollback or spec rollback can clear Error and leave OutOfDate + Updating/Updated.
-	if device.Status.Updated.Status != v1beta1.DeviceUpdatedStatusOutOfDate ||
-		device.Status.Summary.Status != v1beta1.DeviceSummaryStatusOnline {
-		return false
-	}
-	cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceUpdating)
-	if cond == nil {
-		return false
-	}
-	if cond.Status == v1beta1.ConditionStatusTrue {
-		return false
-	}
-	if cond.Reason != string(v1beta1.UpdateStateUpdated) {
 		return false
 	}
 	if len(expectedMessageSubstrings) == 0 {
 		return true
 	}
+	cond := v1beta1.FindStatusCondition(device.Status.Conditions, v1beta1.ConditionTypeDeviceUpdating)
+	if cond == nil {
+		return false
+	}
 	for _, substring := range expectedMessageSubstrings {
 		if strings.Contains(cond.Message, substring) {
 			return true
 		}
-		if device.Status.Updated.Info != nil && strings.Contains(*device.Status.Updated.Info, substring) {
-			return true
-		}
 	}
-	return true
+	return false
 }
 
 // UpdateDeviceAndWaitForFailure updates a device and waits for the update to fail with an error.
-// If expectedMessageSubstrings are provided, it verifies that the error message contains at least one of them
-// (or that the update rolled back, which may not retain the same message text on the status).
+// If expectedMessageSubstrings are provided, it verifies that the error message contains at least one of them.
 func (h *Harness) UpdateDeviceAndWaitForFailure(deviceID string, updateFunc func(device *v1beta1.Device), expectedMessageSubstrings ...string) error {
 	err := h.UpdateDeviceWithRetries(deviceID, updateFunc)
 	if err != nil {
 		return fmt.Errorf("failed to update device: %w", err)
 	}
 
-	description := "update should fail with error or roll back"
+	description := "update should fail with error"
 	if len(expectedMessageSubstrings) > 0 {
-		description = fmt.Sprintf("update should fail with error (or roll back) matching one of: %v", expectedMessageSubstrings)
+		description = fmt.Sprintf("update should fail with error containing one of: %v", expectedMessageSubstrings)
 	}
 
 	h.WaitForDeviceContents(deviceID, description,
 		func(device *v1beta1.Device) bool {
-			return deviceUpdateFailedOrRolledBack(device, expectedMessageSubstrings)
+			return deviceUpdateFailed(device, expectedMessageSubstrings)
 		}, LONGTIMEOUT)
 
 	h.WaitForDeviceContents(deviceID, "device should be out of date but online after failed update",


### PR DESCRIPTION
## Summary
- Persist the formatted sync/prefetch error on `rollback.json` so it survives an OS rollback reboot, instead of being overwritten by `Rebooting` then `Updated`.
- After reboot, bootstrap reports `DeviceUpdating` `Reason=Error` with that message (for example `prefetch failed for quay.io/flightctl/images:doesnotexist`).
- Tighten `UpdateDeviceAndWaitForFailure` so it requires a real Error condition; `OutOfDate` is still asserted afterward, but is no longer treated as a stand-in for Error.

Fixes https://issues.redhat.com/browse/EDM-3773 (replaces stale https://github.com/flightctl/flightctl/pull/2930).

## Test plan
- [ ] Unit tests: `go test ./internal/agent/device/spec/ ./internal/agent/device/`
- [ ] E2E (this PR has `run-e2e`): helm application error handling (`prefetch failed for quay.io/flightctl/images:doesnotexist`) and container nonexistent-image failure (`prefetch failed`)
- [ ] Confirm after OS rollback the updating condition is `Reason=Error` with the prefetch substring, then `status.updated.status=OutOfDate` and `summary=Online`


Made with [Cursor](https://cursor.com)