### PR TITLE
EDM-5290: Fix flaky VM agent helm e2e test 87874 (registry outage across quadlet re-create)

### DIFF
--- a/test/e2e/applications/helm/helm_application_test.go
+++ b/test/e2e/applications/helm/helm_application_test.go
@@ -411,18 +411,32 @@ var _ = Describe("VM Agent Helm Application Tests", Ordered, Label("microshift")
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Disable connectivity from the registry to ensure prefetch relies on old images")
+			By("Disable connectivity to the registry and verify running applications keep using prefetched images")
 			DeferCleanup(func() { _ = harness.FixNetworkFailure(services.Registry.Host, services.Registry.Port) })
 			err = harness.SimulateNetworkFailure(services.Registry.Host, services.Registry.Port)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Already-running workloads must stay healthy while the registry is unreachable: they
+			// run from images the agent prefetched, so a registry outage alone must not degrade them.
+			err = harness.WaitForApplicationStatus(deviceId, quadletAppName, v1beta1.ApplicationStatusRunning, util.TIMEOUT, util.POLLING)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, util.TIMEOUT, util.POLLING)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.WaitForApplicationStatus(deviceId, helmAppName, v1beta1.ApplicationStatusRunning, util.TIMEOUT, util.POLLING)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Restore connectivity before recreating the quadlet in rootless mode. Recreating a quadlet
+			// restarts its generated ".image" units, which run `podman image pull` and always contact
+			// the registry (podman does not fall back to the local cache for a tagged reference). If the
+			// registry were still blocked, the worker container's image pull would fail and the quadlet
+			// would stay partially ready forever.
+			err = harness.FixNetworkFailure(services.Registry.Host, services.Registry.Port)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Swap quadlets back to rootless")
 			err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
 				device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{containerAppSpec, rootlessQuadlet, helmAppSpec}
 			})
-			Expect(err).ToNot(HaveOccurred())
-
-			err = harness.FixNetworkFailure(services.Registry.Host, services.Registry.Port)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Ensure all applications are running")

--- a/test/e2e/applications/helm/helm_application_test.go
+++ b/test/e2e/applications/helm/helm_application_test.go
@@ -411,8 +411,30 @@ var _ = Describe("VM Agent Helm Application Tests", Ordered, Label("microshift")
 			})
 			Expect(err).ToNot(HaveOccurred())
 
+			By("Confirm all applications are running before the registry outage")
+			// UpdateDeviceAndWaitForVersion only waits for the rendered version, so establish the
+			// Running baseline explicitly; otherwise the checks below cannot prove the apps survived
+			// the outage rather than simply having never started.
+			err = harness.WaitForApplicationStatus(deviceId, quadletAppName, v1beta1.ApplicationStatusRunning, util.TIMEOUT, util.POLLING)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, util.TIMEOUT, util.POLLING)
+			Expect(err).ToNot(HaveOccurred())
+			err = harness.WaitForApplicationStatus(deviceId, helmAppName, v1beta1.ApplicationStatusRunning, util.TIMEOUT, util.POLLING)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Disable connectivity to the registry and verify running applications keep using prefetched images")
-			DeferCleanup(func() { _ = harness.FixNetworkFailure(services.Registry.Host, services.Registry.Port) })
+			// The spec restores connectivity explicitly below. FixNetworkFailure deletes the iptables
+			// rule, so calling it a second time errors on the now-absent rule; guard the deferred
+			// restore so it only runs (and is asserted) when the explicit restore has not happened,
+			// e.g. if the spec fails earlier.
+			networkRestored := false
+			DeferCleanup(func() {
+				if networkRestored {
+					return
+				}
+				Expect(harness.FixNetworkFailure(services.Registry.Host, services.Registry.Port)).
+					To(Succeed(), "restore registry connectivity")
+			})
 			err = harness.SimulateNetworkFailure(services.Registry.Host, services.Registry.Port)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -432,6 +454,7 @@ var _ = Describe("VM Agent Helm Application Tests", Ordered, Label("microshift")
 			// would stay partially ready forever.
 			err = harness.FixNetworkFailure(services.Registry.Host, services.Registry.Port)
 			Expect(err).ToNot(HaveOccurred())
+			networkRestored = true
 
 			By("Swap quadlets back to rootless")
 			err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {


### PR DESCRIPTION
## What

Fixes the flaky/failing **87874** test in the VM Agent Helm Application e2e suite (`test/e2e/applications/helm/`).

> Note: this PR originally also carried a fix for **87529** (a shared `EnrollAndWaitForOnlineStatus` race). After rebasing, `main` already contains an equivalent fix — the online wait was refactored into `WaitForOnlineStatus`, which polls with `Eventually(...).Should(Succeed())`. That commit is therefore dropped and this PR now scopes to 87874 only.

## 87874 — registry blocked across a quadlet re-create can never converge

The spec blocked registry connectivity across the rootful→rootless quadlet swap and then waited for the device to reach a `Healthy` applications summary. That never converges: recreating a quadlet restarts its generated `.image` units, which run `podman image pull` and always contact the registry (podman does not fall back to the local cache for a tagged reference). With the registry blocked, the worker container's image pull failed, so `quadlet-app` stayed at 2/3 workloads ready → `ApplicationsSummary` `Degraded` forever → the summary wait timed out.

(The rootful and rootless quadlet specs are the same bundle — only the run-as user differs — so both carry the worker `.image` unit; there is no offline window that can straddle a quadlet re-create.)

### Fix

Scope the offline window to what is genuinely offline-safe:

1. Establish a `Running` baseline for all three apps **before** the outage (`UpdateDeviceAndWaitForVersion` only waits for the rendered version, not for apps to be running).
2. Block the registry and confirm the already-running quadlet/container/helm apps stay `Running` from their prefetched images.
3. Restore connectivity **before** recreating the quadlet in rootless mode, so its mandatory image pull can succeed.
4. Proceed to the `Healthy` summary assertion.

The deferred restore now asserts success (instead of discarding the error) so a failed restore fails visibly rather than leaking a blocked registry into later specs.

## Testing

Full Helm E2E Suite run on CI (fork branch): **7/7 pass, 0 skips** — the Ordered container ran to completion with 87874 green.

| Spec | Result |
|------|--------|
| 87529 deploy/update/remove helm | PASS |
| 87530 deploy multiple app types | PASS |
| 87531 report degraded status | PASS |
| 87532 validate helm error handling | PASS |
| 87874 runAs flightctl apps | PASS |
| 88004 helm app with auth | PASS |
| 88005 image pruning | PASS |

(A fresh CI run on the rebased branch will re-validate 87874.)