### PR TITLE
EDM-5195: patch CVE-2026-33818 (encoding/asn1 DoS) via Go toolchain bump to go1.26.7

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -21,7 +21,7 @@ runs:
         if: ${{ inputs.skip_package_install != 'true' }}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
 
       - name: Prepare apt cache directory
         if: ${{ inputs.skip_package_install != 'true' }}

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
           # setup-go's own built-in cache would otherwise restore/save the exact
           # same ~/.cache/go-build and ~/go/pkg/mod as the "Restore/Save Go modules
           # cache" steps below, redundantly. Worse, its save has no ref gate (see

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/packaging/images/el10/Containerfile.alert-exporter
+++ b/packaging/images/el10/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.alertmanager-proxy
+++ b/packaging/images/el10/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.api
+++ b/packaging/images/el10/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.cli-artifacts
+++ b/packaging/images/el10/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.db-setup
+++ b/packaging/images/el10/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el10/Containerfile.imagebuilder-api
+++ b/packaging/images/el10/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.imagebuilder-worker
+++ b/packaging/images/el10/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.pam-issuer
+++ b/packaging/images/el10/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 

--- a/packaging/images/el10/Containerfile.periodic
+++ b/packaging/images/el10/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.remote-access
+++ b/packaging/images/el10/Containerfile.remote-access
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.telemetry-gateway
+++ b/packaging/images/el10/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.userinfo-proxy
+++ b/packaging/images/el10/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -1,7 +1,7 @@
 # ── vm-to-quadlet build stage ─────────────────────────────────────────────────
 # Isolated from the main build to avoid module-cache contamination — the tool
 # pins k8s.io at a different version than flightctl.
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as vm-to-quadlet-build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as vm-to-quadlet-build
 USER 0
 ARG VM_TO_QUADLET_COMMIT=1acc159843578adad2a27c55f6887c879f68d0c5
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -trimpath -ldflags="-s -w" -o /out/vm-to-quadlet ./cmd/vm-to-quadlet
 
 # ── flightctl worker build stage ─────────────────────────────────────────────
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alert-exporter
+++ b/packaging/images/el9/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alertmanager-proxy
+++ b/packaging/images/el9/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.api
+++ b/packaging/images/el9/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.cli-artifacts
+++ b/packaging/images/el9/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.db-setup
+++ b/packaging/images/el9/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el9/Containerfile.imagebuilder-api
+++ b/packaging/images/el9/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.imagebuilder-worker
+++ b/packaging/images/el9/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.pam-issuer
+++ b/packaging/images/el9/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.periodic
+++ b/packaging/images/el9/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.remote-access
+++ b/packaging/images/el9/Containerfile.remote-access
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.telemetry-gateway
+++ b/packaging/images/el9/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.userinfo-proxy
+++ b/packaging/images/el9/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -1,7 +1,7 @@
 # ── vm-to-quadlet build stage ─────────────────────────────────────────────────
 # Isolated from the main build to avoid module-cache contamination — the tool
 # pins k8s.io at a different version than flightctl.
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as vm-to-quadlet-build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as vm-to-quadlet-build
 USER 0
 ARG VM_TO_QUADLET_COMMIT=1acc159843578adad2a27c55f6887c879f68d0c5
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -trimpath -ldflags="-s -w" -o /out/vm-to-quadlet ./cmd/vm-to-quadlet
 
 # ── flightctl worker build stage ─────────────────────────────────────────────
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/test/integration/tasks/vmrender/Containerfile.vm-to-quadlet
+++ b/test/integration/tasks/vmrender/Containerfile.vm-to-quadlet
@@ -1,5 +1,5 @@
 # Build stage: compile vm-to-quadlet at a pinned commit.
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 AS build
 USER 0
 ARG VM_TO_QUADLET_COMMIT=1acc159843578adad2a27c55f6887c879f68d0c5
 RUN git clone https://github.com/flightctl/vm-to-quadlet /src && \

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/hexdigest/gowrap v1.4.3


### PR DESCRIPTION
## CVE Fix — CVE-2026-33818 (encoding/asn1 recursion DoS)

Resolves CVE-2026-33818 (GO-2026-5972, Important / CVSS 7.5) in `encoding/asn1`
(Go standard library) by bumping the Go toolchain from go1.26.5 to go1.26.7.

The advisory's documented fix is go1.26.6, but Red Hat go-toolset skipped 1.26.6
and its next certified 1.26 release is go1.26.7 (the 1.25 stream tops out at
1.25.9, below the 1.25.13 fix, so it is not a viable route). go1.26.7 is ≥ the
fix version and includes the recursion-limit fix.

Confirmed reachable before the fix via govulncheck:
`pkg/crypto/key.go:280` → `crypto.GetCertificateExtensionValueAsStr` calls
`asn1.Unmarshal`. After the bump, govulncheck (binary/source mode) no longer
reports GO-2026-5972.

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2026-33818 | Important (CVSS 7.5) | encoding/asn1 (Go stdlib, via toolchain) | go1.26.5 | go1.26.7 |

### Changes

- Bumped `toolchain` directive to `go1.26.7` in `go.mod`, `tools/go.mod`, and
  `tools/api-metadata-extractor/go.mod` (the `go 1.26.0` language directive is
  unchanged).
- Updated CI setup-go pins (`.github/actions/setup-dependencies/action.yaml`,
  `.github/workflows/publish-cli-bins.yaml`) to `1.26.7`.
- Bumped all ubi9/ubi10 go-toolset build images to the certified go1.26.7 tags
  (`packaging/images/el9/*` → `1.26.7-1787774815`, `packaging/images/el10/*` →
  `1.26.7-1787775323`, plus `test/integration/tasks/vmrender/Containerfile.vm-to-quadlet`).

### Strategy Justification

**CVE-2026-33818 — encoding/asn1 (Go stdlib)**

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (toolchain bump) | Success | go1.26.5 → go1.26.7 across go.mod files, CI pins, and build images |
| 2 | Transitive update | N/A | Stdlib vuln — no transitive dependency |
| 3 | Override/pin | N/A | Not applicable to a toolchain vuln |
| 4 | Major version update | N/A | Fix available within the 1.26 stream |

### Verification

- `go build ./...` — PASS (toolchain auto-resolved to go1.26.7)
- `go vet ./...` — PASS
- `make unit-test` — PASS (6361 tests, 0 failures, 2 skipped)
- `govulncheck -mode binary` on all 25 compiled binaries — GO-2026-5972 absent
  from every binary (scanner confirmed live: still reports other unrelated vulns).
  Previously reachable via `pkg/crypto/key.go` → `asn1.Unmarshal`.

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```

### Related Jira

- EDM-5195 (flightctl, rhem-1.1) — this repo
- EDM-5194 (flightctl, rhem-1.2) — this repo
