### PR TITLE
EDM-5194: backport CVE-2026-33818 (encoding/asn1 DoS) fix to release-1.2

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -12,7 +12,7 @@ runs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
 
       - name: Enable KVM group perms
         shell: bash

--- a/.github/workflows/publish-cli-bins.yaml
+++ b/.github/workflows/publish-cli-bins.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/ccoveille/go-safecast v1.1.0

--- a/packaging/images/el10/Containerfile.alert-exporter
+++ b/packaging/images/el10/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.alertmanager-proxy
+++ b/packaging/images/el10/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.api
+++ b/packaging/images/el10/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.cli-artifacts
+++ b/packaging/images/el10/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as builder
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.db-setup
+++ b/packaging/images/el10/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el10/Containerfile.imagebuilder-api
+++ b/packaging/images/el10/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.imagebuilder-worker
+++ b/packaging/images/el10/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.pam-issuer
+++ b/packaging/images/el10/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 

--- a/packaging/images/el10/Containerfile.periodic
+++ b/packaging/images/el10/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.telemetry-gateway
+++ b/packaging/images/el10/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.userinfo-proxy
+++ b/packaging/images/el10/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/go-toolset:1.26.5-1787531065 as build
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alert-exporter
+++ b/packaging/images/el9/Containerfile.alert-exporter
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.alertmanager-proxy
+++ b/packaging/images/el9/Containerfile.alertmanager-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.api
+++ b/packaging/images/el9/Containerfile.api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.cli-artifacts
+++ b/packaging/images/el9/Containerfile.cli-artifacts
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as builder
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.db-setup
+++ b/packaging/images/el9/Containerfile.db-setup
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 ARG SOURCE_GIT_TAG
 ARG SOURCE_GIT_TREE_STATE

--- a/packaging/images/el9/Containerfile.imagebuilder-api
+++ b/packaging/images/el9/Containerfile.imagebuilder-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.imagebuilder-worker
+++ b/packaging/images/el9/Containerfile.imagebuilder-worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.pam-issuer
+++ b/packaging/images/el9/Containerfile.pam-issuer
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.periodic
+++ b/packaging/images/el9/Containerfile.periodic
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.telemetry-gateway
+++ b/packaging/images/el9/Containerfile.telemetry-gateway
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.userinfo-proxy
+++ b/packaging/images/el9/Containerfile.userinfo-proxy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1787559109 as build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as build
 WORKDIR /app
 
 # Switch to root for build operations

--- a/tools/api-metadata-extractor/go.mod
+++ b/tools/api-metadata-extractor/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools/api-metadata-extractor
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require sigs.k8s.io/yaml v1.5.0
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/flightctl/flightctl/tools
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/norwoodj/helm-docs v1.14.2


### PR DESCRIPTION
## Backport: CVE-2026-33818 (encoding/asn1 recursion DoS) → release-1.2

Backport of #3480 (merged to `main`) to **release-1.2**.

Resolves **CVE-2026-33818** (GO-2026-5972, Important / CVSS 7.5) in
`encoding/asn1` (Go standard library) by bumping the Go toolchain from
go1.26.5 to **go1.26.7**. The vulnerable `asn1.Unmarshal` is reachable via
`pkg/crypto/key.go` (`crypto.GetCertificateExtensionValueAsStr`).

go1.26.7 is the certified Red Hat go-toolset release (1.26.6 was skipped by
go-toolset) that is ≥ the go1.26.6 upstream fix. ubi9 tag `1.26.7-1787774815`,
ubi10 tag `1.26.7-1787775323`.

### Note on divergence
release-1.2 has diverged from `main`, so a clean cherry-pick of #3480 was not
possible (main added `Containerfile.remote-access` and folded `vm-to-quadlet`
into the worker image; neither exists on release-1.2). The version-string bump
was therefore re-applied directly to release-1.2's actual file set — **29 files**,
one line each. The `go 1.26.0` language directive is unchanged.

### Changes
- `toolchain go1.26.7` in `go.mod`, `tools/go.mod`, `tools/api-metadata-extractor/go.mod`
- CI setup-go pins → `1.26.7` (`setup-dependencies/action.yaml`, `publish-cli-bins.yaml`)
- All ubi9/ubi10 go-toolset build images → certified go1.26.7 tags

### Verification (under go1.26.7)
- `go build ./...` — PASS
- `go vet ./...` — PASS
- `make unit-test` — PASS (4528 tests, 5 skipped [env: Redis], 0 failures)

### Related Jira
- EDM-5194 (flightctl, rhem-1.2)

Source PR: https://github.com/flightctl/flightctl/pull/3480
Source commit: bb229cdbc9b7aa7a8fa95e87d3f7e1de05d52333

Assisted-by: Claude
