### PR TITLE
NO-ISSUE: patch CVE-2026-44740 in go-git/go-billy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-chi/httprate v0.15.0
-	github.com/go-git/go-billy/v5 v5.6.2
+	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.16.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-tpm v0.9.5
@@ -71,7 +71,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0
 	go.uber.org/mock v0.4.0
 	golang.org/x/crypto v0.53.0
-	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
@@ -186,7 +186,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/vcontext v0.0.0-20230201181013-d72178a18687 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
-	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
-github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
+github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -273,8 +273,8 @@ github.com/go-chi/httprate v0.15.0 h1:j54xcWV9KGmPf/X4H32/aTH+wBlrvxL7P+SdnRqxh5
 github.com/go-chi/httprate v0.15.0/go.mod h1:rzGHhVrsBn3IMLYDOZQsSU4fJNWcjui4fWKJcCId1R4=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
-github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=
-github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
+github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmmBPA=
+github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.16.0 h1:k3kuOEpkc0DeY7xlL6NaaNg39xdgQbtH5mwCafHO9AQ=
@@ -1216,8 +1216,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 h1:yqrTHse8TCMW1M1ZCP+VAR/l0kKxwaAIqN/il7x4voA=
-golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
+golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/periodic_checker/publisher.go
+++ b/internal/periodic_checker/publisher.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/rand"
 )
 
 const (
@@ -353,7 +353,7 @@ func (p *PeriodicTaskPublisher) addOrganizationTasks(orgID uuid.UUID) {
 		if staggerRange <= 0 {
 			staggerRange = time.Millisecond
 		}
-		stagger := time.Duration(rand.Intn(int(staggerRange)))
+		stagger := time.Duration(rand.IntN(int(staggerRange))) //nolint:gosec // G404: task-scheduling stagger jitter
 		nextRun := now.Add(stagger)
 
 		task := &ScheduledTask{
@@ -391,7 +391,7 @@ func (p *PeriodicTaskPublisher) addSystemWideTasks() {
 		if staggerRange <= 0 {
 			staggerRange = time.Millisecond
 		}
-		stagger := time.Duration(rand.Intn(int(staggerRange)))
+		stagger := time.Duration(rand.IntN(int(staggerRange))) //nolint:gosec // G404: task-scheduling stagger jitter
 		nextRun := now.Add(stagger)
 
 		// System-wide tasks use a special "system" orgID (nil UUID)


### PR DESCRIPTION
## CVE Fix

Fixes CVE-2026-44740 (GO-2026-5490 / GHSA-m3xc-h892-ggx6) — a denial-of-service in
`github.com/go-git/go-billy/v5`: symlink resolution lacked cycle detection and recursion
depth limits, so a crafted/malformed symlink cycle could drive an infinite loop /
uncontrolled recursion → resource exhaustion (CWE-674/835, CVSS 6.5, availability-only).

govulncheck (source mode) confirmed the vulnerable symbols were **reachable** in shipping
code via `internal/tasks.CloneGitRepo` (git repository-sync task) →
`chroot.ChrootHelper.Chroot` and `chroot.New`. This is a real, reachable finding.

### Vulnerabilities Addressed

| CVE ID | Severity | Package | Old Version | New Version |
|--------|----------|---------|-------------|-------------|
| CVE-2026-44740 | Medium (6.5) | github.com/go-git/go-billy/v5 | v5.6.2 | v5.9.0 |

### Strategy Justification

**CVE-2026-44740 — github.com/go-git/go-billy/v5**

| # | Strategy | Result | Details |
|---|----------|--------|---------|
| 1 | Direct update (minor) | Success | `go get github.com/go-git/go-billy/v5@v5.9.0` + `make tidy`; within same major, low blast radius |

Transitive bumps required by go-billy v5.9.0 (both indirect): `cyphar/filepath-securejoin`
v0.4.1 → v0.6.1, `golang.org/x/exp` bumped.

### Verification
- `make build` → success (all binaries compile).
- govulncheck (GOTOOLCHAIN=go1.26.7, source mode): GO-2026-5490 no longer reported;
  scanner sees go-billy v5.9.0. Overall vuln count 28→26, modules 12→11 (go-billy dropped
  entirely). No new advisory introduced.

### Validation

- Dependencies: go-billy updated to v5.9.0 (`go list -m` confirms).
- Vulnerability scan: **fixed** — GO-2026-5490 absent from compiled binaries
  (`govulncheck -mode binary` on flightctl-worker/periodic/api) and from source scan.
- Tests: `make unit-test` — 6374 tests, 2 skipped, 0 real failures (one environmental
  ETXTBSY flake in an unrelated VM→quadlet exec test, green on retry).

### Related

- Dependabot PR #3352 bumps the sibling library `go-git/go-git` 5.16.0→5.19.2 (separate
  NO-ISSUE change, not this CVE). This PR targets go-billy directly per the tracking tickets.

### Rollback

To revert this change:
```bash
git revert <commit-sha>
```
