### PR TITLE
NO-ISSUE: pin setup-go cache-dependency-path to avoid post-step cache failure (release-1.2)

### DIFF
--- a/.github/actions/setup-dependencies/action.yaml
+++ b/.github/actions/setup-dependencies/action.yaml
@@ -9,10 +9,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+      # Pin cache-dependency-path to the root go.sum. Left unset, setup-go
+      # resolves the cache key by searching for go.sum across the repo, and
+      # this repo has several (root plus tools/*/go.sum). That ambiguous
+      # resolution intermittently trips a runner-toolkit bug in setup-go's
+      # post-step cache save ("Index was out of range"), which fails the job
+      # even when all build/test steps pass. It surfaces on release branches
+      # (cold cache -> the save path actually runs) far more than on main
+      # (warm exact-key hit -> save skipped). Anchoring the key to a single
+      # file that exists on every branch makes resolution deterministic while
+      # keeping setup-go's built-in caching and its correct post-step save
+      # timing (after go install and the caller's make targets complete).
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.26.7'
+          cache-dependency-path: go.sum
 
       - name: Enable KVM group perms
         shell: bash


### PR DESCRIPTION
## Summary

Backport of #3488 to **release-1.2**.

Fixes intermittent CI job failures on release branches where the job fails in a post (cleanup) step even though all build/test steps pass, with:

```
##[error]Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
```

## Root cause

`actions/setup-go@v5` resolves its cache key by searching for `go.sum` across the repo when `cache-dependency-path` is unset. This branch has several `go.sum` files (root plus `tools/*/go.sum`), and that ambiguous resolution intermittently trips a runner-toolkit bug in setup-go's **post-step cache save** (`Index was out of range`), failing the job even when all build/test steps pass. setup-go only runs the save on a cache miss, which is common on release branches (cold cache), so this surfaces here far more than on main.

## Fix

Pin `cache-dependency-path: go.sum` on the `actions/setup-go@v5` step so key resolution is deterministic, while keeping setup-go's built-in caching.

## Note on backport method

The `setup-dependencies` action on release-1.2 differs substantially from main (no `skip_package_install`/apt-cache steps), so `2c2f1d073` does not cherry-pick cleanly. This is an **equivalent manual edit** producing the same effective change on this branch's file.

Assisted-by: Claude
