### PR TITLE
EDM-4892: remove empty directories after removing a host configuration source

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -361,6 +361,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	// create config controller
 	configController := config.NewController(
 		rootReadWriter,
+		a.config.DataDir,
 		a.log,
 	)
 

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
 	deviceerrors "github.com/flightctl/flightctl/internal/agent/device/errors"
@@ -96,7 +99,101 @@ func (c *Controller) removeObsoleteFiles(currentFiles, desiredFiles []v1beta1.Fi
 			return fmt.Errorf("%w %w: %w", deviceerrors.ErrDeletingFilesFailed, deviceerrors.WithElement(file), err)
 		}
 	}
+	// Fix for EDM-4892: removing the files is not enough. A removed host
+	// configuration source (e.g. a git repo populating
+	// /etc/microshift/manifests.d/) also creates directories to hold those
+	// files; without cleaning them up the device is left with a stale, empty
+	// directory tree that reads as "content still present" after the source is
+	// removed. This is best-effort cleanup and never fails the reconcile.
+	c.removeEmptyDirs(removeFiles, desiredFiles)
 	return nil
+}
+
+// protectedDirs are directories we never remove during empty-directory cleanup,
+// even if they end up empty. They are well-known system roots; removing them
+// would be surprising and outside the scope of tidying up config-managed files.
+var protectedDirs = map[string]bool{
+	"/":     true,
+	"/etc":  true,
+	"/var":  true,
+	"/usr":  true,
+	"/opt":  true,
+	"/run":  true,
+	"/home": true,
+	"/root": true,
+	"/boot": true,
+	"/tmp":  true,
+	"/srv":  true,
+	"/mnt":  true,
+	"/dev":  true,
+	"/proc": true,
+	"/sys":  true,
+	"/lib":  true,
+	"/bin":  true,
+	"/sbin": true,
+}
+
+// removeEmptyDirs removes directories left empty after obsolete files were
+// deleted. It walks up the parent directories of each removed file (deepest
+// first) and removes each one that is now empty, stopping at protected system
+// roots. Directories that still hold desired files are preserved, as are any
+// directories that still contain other content (RemoveEmptyDir is a no-op on
+// non-empty directories). Cleanup failures are logged, never fatal.
+func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1beta1.FileSpec) {
+	// Preserve every directory a desired file lives under: those directories are
+	// needed by the subsequent write step and must not be pruned.
+	keep := make(map[string]bool)
+	for _, file := range getFilePaths(desiredFiles) {
+		for dir := filepath.Dir(file); isCleanupCandidate(dir); dir = filepath.Dir(dir) {
+			keep[dir] = true
+		}
+	}
+
+	// Collect the unique set of candidate directories from the removed files.
+	candidates := make(map[string]bool)
+	for _, file := range removedFiles {
+		if len(file) == 0 {
+			continue
+		}
+		for dir := filepath.Dir(file); isCleanupCandidate(dir); dir = filepath.Dir(dir) {
+			candidates[dir] = true
+		}
+	}
+
+	// Remove deepest directories first so that parents become empty (and thus
+	// removable) only after their now-empty children are gone.
+	dirs := make([]string, 0, len(candidates))
+	for dir := range candidates {
+		if keep[dir] {
+			continue
+		}
+		dirs = append(dirs, dir)
+	}
+	sort.Slice(dirs, func(i, j int) bool {
+		di, dj := strings.Count(dirs[i], "/"), strings.Count(dirs[j], "/")
+		if di != dj {
+			return di > dj
+		}
+		// Deterministic ordering for siblings at the same depth.
+		return dirs[i] < dirs[j]
+	})
+
+	for _, dir := range dirs {
+		if err := c.deviceWriter.RemoveEmptyDir(dir); err != nil {
+			c.log.Warnf("Failed to remove empty directory %s: %v", dir, err)
+			continue
+		}
+		c.log.Debugf("Removed empty directory: %s", dir)
+	}
+}
+
+// isCleanupCandidate reports whether dir may be considered for empty-directory
+// cleanup. Empty, relative, and protected system directories are excluded.
+func isCleanupCandidate(dir string) bool {
+	if dir == "" || dir == "." {
+		return false
+	}
+	return !protectedDirs[filepath.Clean(dir)]
 }
 
 func (c *Controller) writeFiles(files []v1beta1.FileSpec) error {

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -109,36 +109,13 @@ func (c *Controller) removeObsoleteFiles(currentFiles, desiredFiles []v1beta1.Fi
 	return nil
 }
 
-// protectedDirs are directories we never remove during empty-directory cleanup,
-// even if they end up empty. They are well-known system roots; removing them
-// would be surprising and outside the scope of tidying up config-managed files.
-var protectedDirs = map[string]bool{
-	"/":     true,
-	"/etc":  true,
-	"/var":  true,
-	"/usr":  true,
-	"/opt":  true,
-	"/run":  true,
-	"/home": true,
-	"/root": true,
-	"/boot": true,
-	"/tmp":  true,
-	"/srv":  true,
-	"/mnt":  true,
-	"/dev":  true,
-	"/proc": true,
-	"/sys":  true,
-	"/lib":  true,
-	"/bin":  true,
-	"/sbin": true,
-}
-
 // removeEmptyDirs removes directories left empty after obsolete files were
 // deleted. It walks up the parent directories of each removed file (deepest
-// first) and removes each one that is now empty, stopping at protected system
-// roots. Directories that still hold desired files are preserved, as are any
-// directories that still contain other content (RemoveEmptyDir is a no-op on
-// non-empty directories). Cleanup failures are logged, never fatal.
+// first) and removes each one that is now empty, stopping before top-level
+// directories (see isCleanupCandidate). Directories that still hold desired
+// files are preserved, as are any directories that still contain other content
+// (RemoveEmptyDir is a no-op on non-empty directories). Cleanup failures are
+// logged, never fatal.
 func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1beta1.FileSpec) {
 	// Preserve every directory a desired file lives under: those directories are
 	// needed by the subsequent write step and must not be pruned.
@@ -188,9 +165,13 @@ func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1bet
 }
 
 // isCleanupCandidate reports whether dir may be considered for empty-directory
-// cleanup. Empty, relative, and protected system directories are excluded.
-// Requiring an absolute path guards against traversal: a rendered path such as
-// "../etc" must never be joined with the writer root and removed.
+// cleanup. The root and any of its direct children (top-level directories such
+// as /etc, /var, /media, /lib64) are never removed: pruning a top-level
+// directory is surprising and outside the scope of tidying up config-managed
+// files, and an allowlist of well-known roots would inevitably miss some.
+// Empty and relative paths are also excluded; requiring an absolute path guards
+// against traversal so a rendered path such as "../etc" can never be joined
+// with the writer root and removed.
 func isCleanupCandidate(dir string) bool {
 	if dir == "" || dir == "." {
 		return false
@@ -199,7 +180,8 @@ func isCleanupCandidate(dir string) bool {
 	if !filepath.IsAbs(cleaned) {
 		return false
 	}
-	return !protectedDirs[cleaned]
+	// Never remove the root or a top-level directory (a direct child of "/").
+	return filepath.Dir(cleaned) != "/"
 }
 
 func (c *Controller) writeFiles(files []v1beta1.FileSpec) error {

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -137,8 +137,10 @@ func (c *Controller) removeObsoleteFiles(currentFiles, desiredFiles []v1beta1.Fi
 // Directories that still hold desired files are preserved, as are any that still
 // contain other content (RemoveEmptyDir is a no-op on non-empty directories).
 // Top-level and relative paths are excluded by isCleanupCandidate. Cleanup
-// failures are logged, never fatal. Successfully removed directories are dropped
-// from owned; it reports whether owned changed.
+// failures are logged, never fatal; a directory whose removal errors keeps its
+// ownership so the next reconcile retries. Ownership is otherwise relinquished
+// after the best-effort attempt — whether the directory was removed or preserved
+// — so it reports whether owned changed.
 func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1beta1.FileSpec, owned map[string]bool) bool {
 	// Preserve every directory a desired file lives under: those directories are
 	// needed by the subsequent write step and must not be pruned.
@@ -181,11 +183,18 @@ func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1bet
 
 	changed := false
 	for _, dir := range dirs {
-		if err := c.deviceReadWriter.RemoveEmptyDir(dir); err != nil {
+		removed, err := c.deviceReadWriter.RemoveEmptyDir(dir)
+		if err != nil {
+			// Keep ownership so the next reconcile retries the removal.
 			c.log.Warnf("Failed to remove empty directory %s: %v", dir, err)
 			continue
 		}
-		c.log.Debugf("Removed empty directory: %s", dir)
+		if removed {
+			c.log.Debugf("Removed empty directory: %s", dir)
+		}
+		// Relinquish ownership after the best-effort attempt: a directory that was
+		// preserved (it still holds unmanaged content, or is a symlink) is no
+		// longer tracked either way, so cleanup never revisits it.
 		delete(owned, dir)
 		changed = true
 	}

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -99,12 +99,7 @@ func (c *Controller) removeObsoleteFiles(currentFiles, desiredFiles []v1beta1.Fi
 			return fmt.Errorf("%w %w: %w", deviceerrors.ErrDeletingFilesFailed, deviceerrors.WithElement(file), err)
 		}
 	}
-	// Fix for EDM-4892: removing the files is not enough. A removed host
-	// configuration source (e.g. a git repo populating
-	// /etc/microshift/manifests.d/) also creates directories to hold those
-	// files; without cleaning them up the device is left with a stale, empty
-	// directory tree that reads as "content still present" after the source is
-	// removed. This is best-effort cleanup and never fails the reconcile.
+	// Remove empty managed directories left after obsolete files are deleted.
 	c.removeEmptyDirs(removeFiles, desiredFiles)
 	return nil
 }

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -18,18 +18,22 @@ import (
 // Config controller is responsible for ensuring the device configuration is reconciled
 // against the device spec.
 type Controller struct {
-	deviceWriter fileio.Writer
-	log          *log.PrefixLogger
+	deviceReadWriter fileio.ReadWriter
+	dataDir          string
+	log              *log.PrefixLogger
 }
 
-// NewController creates a new config controller.
+// NewController creates a new config controller. dataDir is the agent data
+// directory under which the managed-directory ownership manifest is persisted.
 func NewController(
-	deviceWriter fileio.Writer,
+	deviceReadWriter fileio.ReadWriter,
+	dataDir string,
 	log *log.PrefixLogger,
 ) *Controller {
 	return &Controller{
-		deviceWriter: deviceWriter,
-		log:          log,
+		deviceReadWriter: deviceReadWriter,
+		dataDir:          dataDir,
+		log:              log,
 	}
 }
 
@@ -70,48 +74,72 @@ func computeRemoval(currentFileList, desiredFileList []v1beta1.FileSpec) []strin
 }
 
 func (c *Controller) ensureConfigFiles(currentFiles, desiredFiles []v1beta1.FileSpec) error {
-	if err := c.removeObsoleteFiles(currentFiles, desiredFiles); err != nil {
+	// owned is the set of directories the agent created for managed files. It
+	// gates empty-directory cleanup so the agent only removes directories it
+	// created, and is persisted across reconciles (and reboots).
+	owned := c.loadManagedDirectories()
+	dirty := false
+
+	removed, err := c.removeObsoleteFiles(currentFiles, desiredFiles, owned)
+	if err != nil {
 		return fmt.Errorf("%w: %w", deviceerrors.ErrFailedToRemoveObsoleteFiles, err)
 	}
+	dirty = dirty || removed
 
 	if len(desiredFiles) == 0 {
 		c.log.Debug("No config files to write")
-		// no files to write
-		return nil
+	} else {
+		// Record the directories the agent is about to create before writing, so
+		// they become eligible for future cleanup.
+		if c.recordNewDirectories(desiredFiles, owned) {
+			dirty = true
+		}
+		if err := c.writeFiles(desiredFiles); err != nil {
+			c.log.Warnf("Writing config files failed: %+v", err)
+			return fmt.Errorf("failed to apply configuration: %w", err)
+		}
 	}
 
-	if err := c.writeFiles(desiredFiles); err != nil {
-		c.log.Warnf("Writing config files failed: %+v", err)
-		return fmt.Errorf("failed to apply configuration: %w", err)
+	if dirty {
+		if err := c.saveManagedDirectories(owned); err != nil {
+			// Persisting ownership is best-effort: a failure only means some
+			// directories may not be cleaned up later, never a failed sync.
+			c.log.Warnf("Failed to persist managed directory ownership: %v", err)
+		}
 	}
 	return nil
 }
 
-// removeObsoleteFiles removes files that are present in the currentFiles but not in the desiredFiles.
-func (c *Controller) removeObsoleteFiles(currentFiles, desiredFiles []v1beta1.FileSpec) error {
+// removeObsoleteFiles removes files that are present in the currentFiles but not
+// in the desiredFiles, then prunes any now-empty directories the agent created.
+// It reports whether the owned-directory set changed.
+func (c *Controller) removeObsoleteFiles(currentFiles, desiredFiles []v1beta1.FileSpec, owned map[string]bool) (bool, error) {
 	removeFiles := computeRemoval(currentFiles, desiredFiles)
 	for _, file := range removeFiles {
 		if len(file) == 0 {
 			continue
 		}
 		c.log.Debugf("Deleting file: %s", file)
-		if err := c.deviceWriter.RemoveFile(file); err != nil {
-			return fmt.Errorf("%w %w: %w", deviceerrors.ErrDeletingFilesFailed, deviceerrors.WithElement(file), err)
+		if err := c.deviceReadWriter.RemoveFile(file); err != nil {
+			return false, fmt.Errorf("%w %w: %w", deviceerrors.ErrDeletingFilesFailed, deviceerrors.WithElement(file), err)
 		}
 	}
 	// Remove empty managed directories left after obsolete files are deleted.
-	c.removeEmptyDirs(removeFiles, desiredFiles)
-	return nil
+	changed := c.removeEmptyDirs(removeFiles, desiredFiles, owned)
+	return changed, nil
 }
 
 // removeEmptyDirs removes directories left empty after obsolete files were
 // deleted. It walks up the parent directories of each removed file (deepest
-// first) and removes each one that is now empty, stopping before top-level
-// directories (see isCleanupCandidate). Directories that still hold desired
-// files are preserved, as are any directories that still contain other content
-// (RemoveEmptyDir is a no-op on non-empty directories). Cleanup failures are
-// logged, never fatal.
-func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1beta1.FileSpec) {
+// first) and removes each one that is now empty, but only if the agent created
+// it (owned); directories the agent did not create — pre-existing, package- or
+// user-owned directories that merely held a managed file — are never removed.
+// Directories that still hold desired files are preserved, as are any that still
+// contain other content (RemoveEmptyDir is a no-op on non-empty directories).
+// Top-level and relative paths are excluded by isCleanupCandidate. Cleanup
+// failures are logged, never fatal. Successfully removed directories are dropped
+// from owned; it reports whether owned changed.
+func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1beta1.FileSpec, owned map[string]bool) bool {
 	// Preserve every directory a desired file lives under: those directories are
 	// needed by the subsequent write step and must not be pruned.
 	keep := make(map[string]bool)
@@ -133,10 +161,11 @@ func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1bet
 	}
 
 	// Remove deepest directories first so that parents become empty (and thus
-	// removable) only after their now-empty children are gone.
+	// removable) only after their now-empty children are gone. Only directories
+	// the agent created (owned) and not needed by a desired file are eligible.
 	dirs := make([]string, 0, len(candidates))
 	for dir := range candidates {
-		if keep[dir] {
+		if keep[dir] || !owned[dir] {
 			continue
 		}
 		dirs = append(dirs, dir)
@@ -150,13 +179,17 @@ func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1bet
 		return dirs[i] < dirs[j]
 	})
 
+	changed := false
 	for _, dir := range dirs {
-		if err := c.deviceWriter.RemoveEmptyDir(dir); err != nil {
+		if err := c.deviceReadWriter.RemoveEmptyDir(dir); err != nil {
 			c.log.Warnf("Failed to remove empty directory %s: %v", dir, err)
 			continue
 		}
 		c.log.Debugf("Removed empty directory: %s", dir)
+		delete(owned, dir)
+		changed = true
 	}
+	return changed
 }
 
 // isCleanupCandidate reports whether dir may be considered for empty-directory
@@ -181,7 +214,7 @@ func isCleanupCandidate(dir string) bool {
 
 func (c *Controller) writeFiles(files []v1beta1.FileSpec) error {
 	for _, file := range files {
-		managedFile, err := c.deviceWriter.CreateManagedFile(file)
+		managedFile, err := c.deviceReadWriter.CreateManagedFile(file)
 		if err != nil {
 			return fmt.Errorf("creating managed file %w: %w", deviceerrors.WithElement(file.Path), err)
 		}

--- a/internal/agent/device/config/controller.go
+++ b/internal/agent/device/config/controller.go
@@ -189,11 +189,17 @@ func (c *Controller) removeEmptyDirs(removedFiles []string, desiredFiles []v1bet
 
 // isCleanupCandidate reports whether dir may be considered for empty-directory
 // cleanup. Empty, relative, and protected system directories are excluded.
+// Requiring an absolute path guards against traversal: a rendered path such as
+// "../etc" must never be joined with the writer root and removed.
 func isCleanupCandidate(dir string) bool {
 	if dir == "" || dir == "." {
 		return false
 	}
-	return !protectedDirs[filepath.Clean(dir)]
+	cleaned := filepath.Clean(dir)
+	if !filepath.IsAbs(cleaned) {
+		return false
+	}
+	return !protectedDirs[cleaned]
 }
 
 func (c *Controller) writeFiles(files []v1beta1.FileSpec) error {

--- a/internal/agent/device/config/controller_test.go
+++ b/internal/agent/device/config/controller_test.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/flightctl/flightctl/api/core/v1beta1"
@@ -19,7 +21,7 @@ func TestSync(t *testing.T) {
 		name       string
 		current    *v1beta1.DeviceSpec
 		desired    *v1beta1.DeviceSpec
-		setupMocks func(mockWriter *fileio.MockWriter, mockManagedFile *fileio.MockManagedFile, f string)
+		setupMocks func(mockWriter *fileio.MockReadWriter, mockManagedFile *fileio.MockManagedFile, f string)
 		wantErr    error
 		// files which are created via the sync operation
 		createdFiles []string
@@ -27,6 +29,9 @@ func TestSync(t *testing.T) {
 		removedFiles []string
 		// directories that become empty and are cleaned up via the sync operation
 		removedDirs []string
+		// directories the agent previously created (loaded from the ownership
+		// manifest); only these are eligible for cleanup
+		ownedDirs []string
 	}{
 		{
 			name:    "no desired config",
@@ -60,6 +65,9 @@ func TestSync(t *testing.T) {
 			removedDirs: []string{
 				"/etc/example",
 			},
+			ownedDirs: []string{
+				"/etc/example",
+			},
 		},
 		{
 			name: "validate removal of files",
@@ -85,12 +93,15 @@ func TestSync(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockWriter := fileio.NewMockWriter(ctrl)
+			mockWriter := fileio.NewMockReadWriter(ctrl)
 			mockManagedFile := fileio.NewMockManagedFile(ctrl)
 			controller := NewController(
 				mockWriter,
+				"/var/lib/flightctl",
 				log.NewPrefixLogger("test"),
 			)
+
+			expectManagedDirectories(mockWriter, tt.ownedDirs)
 
 			for _, f := range tt.createdFiles {
 				expectCreateFile(mockWriter, mockManagedFile, f)
@@ -172,19 +183,36 @@ func TestComputeRemoval(t *testing.T) {
 	}
 }
 
-func expectCreateFile(mockWriter *fileio.MockWriter, mockManagedFile *fileio.MockManagedFile, _ string) {
+func expectCreateFile(mockWriter *fileio.MockReadWriter, mockManagedFile *fileio.MockManagedFile, _ string) {
 	mockWriter.EXPECT().CreateManagedFile(gomock.Any()).Return(mockManagedFile, nil)
 	mockManagedFile.EXPECT().IsUpToDate().Return(false, nil)
 	mockManagedFile.EXPECT().Exists().Return(false, nil)
 	mockManagedFile.EXPECT().Write().Return(nil)
 }
 
-func expectRemoveFile(mockWriter *fileio.MockWriter, f string) {
+func expectRemoveFile(mockWriter *fileio.MockReadWriter, f string) {
 	mockWriter.EXPECT().RemoveFile(f).Return(nil)
 }
 
-func expectRemoveEmptyDir(mockWriter *fileio.MockWriter, d string) {
+func expectRemoveEmptyDir(mockWriter *fileio.MockReadWriter, d string) {
 	mockWriter.EXPECT().RemoveEmptyDir(d).Return(nil)
+}
+
+// expectManagedDirectories wires the ownership-manifest I/O the controller
+// performs each sync: reading the previously owned set (ownedDirs, or a missing
+// manifest when empty), probing whether about-to-be-created directories exist,
+// and persisting the updated set. These are tolerant (AnyTimes) so individual
+// test cases only assert on file and directory operations.
+func expectManagedDirectories(mockWriter *fileio.MockReadWriter, ownedDirs []string) {
+	if len(ownedDirs) == 0 {
+		mockWriter.EXPECT().ReadFile(gomock.Any()).Return(nil, os.ErrNotExist).AnyTimes()
+	} else {
+		data, _ := json.Marshal(managedDirectories{Directories: ownedDirs})
+		mockWriter.EXPECT().ReadFile(gomock.Any()).Return(data, nil).AnyTimes()
+	}
+	// About-to-be-created directories are reported absent so they are tracked.
+	mockWriter.EXPECT().PathExists(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
+	mockWriter.EXPECT().WriteFile(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 }
 
 func testConfigProvider(require *require.Assertions, fileCount int) *[]v1beta1.ConfigProviderSpec {

--- a/internal/agent/device/config/controller_test.go
+++ b/internal/agent/device/config/controller_test.go
@@ -25,6 +25,8 @@ func TestSync(t *testing.T) {
 		createdFiles []string
 		// files which are removed via the sync operation
 		removedFiles []string
+		// directories that become empty and are cleaned up via the sync operation
+		removedDirs []string
 	}{
 		{
 			name:    "no desired config",
@@ -54,6 +56,9 @@ func TestSync(t *testing.T) {
 				"/etc/example/file1.txt",
 				"/etc/example/file2.txt",
 				"/etc/example/file3.txt",
+			},
+			removedDirs: []string{
+				"/etc/example",
 			},
 		},
 		{
@@ -93,6 +98,10 @@ func TestSync(t *testing.T) {
 
 			for _, f := range tt.removedFiles {
 				expectRemoveFile(mockWriter, f)
+			}
+
+			for _, d := range tt.removedDirs {
+				expectRemoveEmptyDir(mockWriter, d)
 			}
 
 			err := controller.Sync(ctx, tt.current, tt.desired)
@@ -172,6 +181,10 @@ func expectCreateFile(mockWriter *fileio.MockWriter, mockManagedFile *fileio.Moc
 
 func expectRemoveFile(mockWriter *fileio.MockWriter, f string) {
 	mockWriter.EXPECT().RemoveFile(f).Return(nil)
+}
+
+func expectRemoveEmptyDir(mockWriter *fileio.MockWriter, d string) {
+	mockWriter.EXPECT().RemoveEmptyDir(d).Return(nil)
 }
 
 func testConfigProvider(require *require.Assertions, fileCount int) *[]v1beta1.ConfigProviderSpec {

--- a/internal/agent/device/config/controller_test.go
+++ b/internal/agent/device/config/controller_test.go
@@ -195,7 +195,7 @@ func expectRemoveFile(mockWriter *fileio.MockReadWriter, f string) {
 }
 
 func expectRemoveEmptyDir(mockWriter *fileio.MockReadWriter, d string) {
-	mockWriter.EXPECT().RemoveEmptyDir(d).Return(nil)
+	mockWriter.EXPECT().RemoveEmptyDir(d).Return(true, nil)
 }
 
 // expectManagedDirectories wires the ownership-manifest I/O the controller

--- a/internal/agent/device/config/directory_ownership.go
+++ b/internal/agent/device/config/directory_ownership.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+)
+
+// ManagedDirectoriesFileName is the name of the file, stored under the agent
+// data directory, that records the directories the agent created while writing
+// managed config files. Only directories in this set are eligible for
+// empty-directory cleanup, so the agent never removes a directory it did not
+// create (for example a package- or user-owned directory that happens to hold a
+// managed file).
+const ManagedDirectoriesFileName = "managed-directories.json"
+
+// managedDirectories is the on-disk representation of the agent-created
+// directory set. It mirrors the lightweight JSON-manifest pattern used elsewhere
+// in the agent (e.g. image pruning's references file) rather than introducing a
+// new persistence mechanism.
+type managedDirectories struct {
+	Timestamp   string   `json:"timestamp"`
+	Directories []string `json:"directories"`
+}
+
+// managedDirectoriesPath returns the full path to the ownership manifest under
+// the agent data directory.
+func (c *Controller) managedDirectoriesPath() string {
+	return filepath.Join(c.dataDir, ManagedDirectoriesFileName)
+}
+
+// loadManagedDirectories reads the agent-created directory set from disk. A
+// missing manifest yields an empty set. A read or decode error is logged and
+// also yields an empty set: ownership tracking is best-effort and must never
+// fail reconciliation, and an empty set is the safe default (nothing is
+// eligible for cleanup).
+func (c *Controller) loadManagedDirectories() map[string]bool {
+	owned := make(map[string]bool)
+	data, err := c.deviceReadWriter.ReadFile(c.managedDirectoriesPath())
+	if err != nil {
+		if !os.IsNotExist(err) {
+			c.log.Warnf("Failed to read managed directory manifest: %v", err)
+		}
+		return owned
+	}
+	var manifest managedDirectories
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		c.log.Warnf("Failed to parse managed directory manifest; ignoring it: %v", err)
+		return owned
+	}
+	for _, dir := range manifest.Directories {
+		owned[dir] = true
+	}
+	return owned
+}
+
+// saveManagedDirectories persists the agent-created directory set to disk. The
+// entries are sorted so the manifest is stable across writes.
+func (c *Controller) saveManagedDirectories(owned map[string]bool) error {
+	dirs := make([]string, 0, len(owned))
+	for dir := range owned {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	data, err := json.Marshal(managedDirectories{
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Directories: dirs,
+	})
+	if err != nil {
+		return err
+	}
+	return c.deviceReadWriter.WriteFile(c.managedDirectoriesPath(), data, fileio.DefaultFilePermissions)
+}
+
+// recordNewDirectories records, as agent-created, every cleanup-candidate parent
+// directory of the desired files that does not yet exist on disk. It must be
+// called before the files are written (which creates those directories via
+// MkdirAll): a directory that is absent now but present after the write is one
+// the agent created. Directories that already exist are left untracked so
+// cleanup never removes pre-existing, non-agent-owned directories. It reports
+// whether the owned set changed.
+func (c *Controller) recordNewDirectories(desiredFiles []v1beta1.FileSpec, owned map[string]bool) bool {
+	changed := false
+	for _, file := range getFilePaths(desiredFiles) {
+		for dir := filepath.Dir(file); isCleanupCandidate(dir); dir = filepath.Dir(dir) {
+			if owned[dir] {
+				continue
+			}
+			exists, err := c.deviceReadWriter.PathExists(dir, fileio.WithSkipContentCheck())
+			if err != nil {
+				// On an unexpected stat error, err on the side of not claiming
+				// ownership: an untracked directory is never removed.
+				c.log.Warnf("Failed to check directory %s for ownership tracking: %v", dir, err)
+				continue
+			}
+			if exists {
+				continue
+			}
+			owned[dir] = true
+			changed = true
+		}
+	}
+	return changed
+}

--- a/internal/agent/device/config/removal_test.go
+++ b/internal/agent/device/config/removal_test.go
@@ -243,6 +243,11 @@ func TestIsCleanupCandidate(t *testing.T) {
 		{"/etc/microshift", true},
 		{"/etc/microshift/manifests.d", true},
 		{"/opt/app/data", true},
+		// relative paths must never be cleanup candidates: joined with the
+		// writer root they could traverse outside it (e.g. "../etc").
+		{"../etc", false},
+		{"etc/microshift", false},
+		{"./opt/app/data", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.dir, func(t *testing.T) {

--- a/internal/agent/device/config/removal_test.go
+++ b/internal/agent/device/config/removal_test.go
@@ -1,0 +1,252 @@
+package config
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/agent/device/fileio"
+	"github.com/flightctl/flightctl/pkg/log"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// inlineProvider builds a single inline config provider owning the given files,
+// mirroring how the service renders every config source into one inline provider
+// before the agent reconciles it. Ownership defaults to the current process so
+// the real writer does not attempt a privileged chown during tests.
+func inlineProvider(t *testing.T, paths ...string) *[]v1beta1.ConfigProviderSpec {
+	t.Helper()
+	cur, err := user.Current()
+	require.NoError(t, err)
+
+	files := make([]v1beta1.FileSpec, 0, len(paths))
+	for _, path := range paths {
+		files = append(files, v1beta1.FileSpec{
+			Path:    path,
+			Content: "content of " + path,
+			Mode:    lo.ToPtr(0o644),
+			User:    v1beta1.Username(cur.Uid),
+			Group:   cur.Gid,
+		})
+	}
+
+	var provider v1beta1.ConfigProviderSpec
+	require.NoError(t, provider.FromInlineConfigProviderSpec(v1beta1.InlineConfigProviderSpec{Inline: files}))
+	return &[]v1beta1.ConfigProviderSpec{provider}
+}
+
+// TestSyncRemovesEmptyDirs_EDM4892 reproduces the reported scenario end-to-end
+// with a real writer: a host configuration (e.g. MicroShift manifests from a
+// git repo) populates a nested directory tree, then the source is removed. Both
+// the files and the directories created to hold them must be gone afterwards.
+func TestSyncRemovesEmptyDirs_EDM4892(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	rw := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
+	)
+	controller := NewController(rw, log.NewPrefixLogger("test"))
+
+	files := []string{
+		"/etc/microshift/manifests.d/app1/kustomization.yaml",
+		"/etc/microshift/manifests.d/app1/deploy.yaml",
+		"/etc/microshift/manifests.d/app2/svc.yaml",
+	}
+
+	// Add the source: files are written to disk.
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{},
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, files...)},
+	))
+	for _, f := range files {
+		_, err := os.Stat(filepath.Join(tempDir, f))
+		require.NoError(err, "file should exist after applying the source: %s", f)
+	}
+
+	// Remove the source: files and the now-empty directory tree must be removed.
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, files...)},
+		&v1beta1.DeviceSpec{},
+	))
+
+	for _, f := range files {
+		_, err := os.Stat(filepath.Join(tempDir, f))
+		require.True(os.IsNotExist(err), "file should be removed after source removal: %s", f)
+	}
+	for _, dir := range []string{
+		"/etc/microshift/manifests.d/app1",
+		"/etc/microshift/manifests.d/app2",
+		"/etc/microshift/manifests.d",
+		"/etc/microshift",
+	} {
+		_, err := os.Stat(filepath.Join(tempDir, dir))
+		require.True(os.IsNotExist(err), "empty directory should be cleaned up: %s", dir)
+	}
+	// /etc is a protected system root and must never be removed.
+	_, err := os.Stat(filepath.Join(tempDir, "/etc"))
+	require.NoError(err, "/etc must not be removed")
+}
+
+// TestSyncPreservesSharedDirs verifies that removing some files under a
+// directory that still holds desired files leaves that directory (and its
+// remaining files) intact.
+func TestSyncPreservesSharedDirs(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	rw := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
+	)
+	controller := NewController(rw, log.NewPrefixLogger("test"))
+
+	kept := "/etc/microshift/manifests.d/app/keep.yaml"
+	removed := "/etc/microshift/manifests.d/app/remove.yaml"
+
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{},
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, kept, removed)},
+	))
+
+	// Drop one file; the other remains desired.
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, kept, removed)},
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, kept)},
+	))
+
+	_, err := os.Stat(filepath.Join(tempDir, removed))
+	require.True(os.IsNotExist(err), "removed file should be gone")
+	_, err = os.Stat(filepath.Join(tempDir, kept))
+	require.NoError(err, "desired file must remain")
+	_, err = os.Stat(filepath.Join(tempDir, "/etc/microshift/manifests.d/app"))
+	require.NoError(err, "shared directory holding a desired file must remain")
+}
+
+// TestSyncPreservesNonEmptyDirs verifies that a directory holding unmanaged
+// content (files not part of any config source) is never removed.
+func TestSyncPreservesNonEmptyDirs(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	rw := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
+	)
+	controller := NewController(rw, log.NewPrefixLogger("test"))
+
+	managed := "/etc/microshift/manifests.d/app/managed.yaml"
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{},
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, managed)},
+	))
+
+	// Drop an unmanaged file into the same directory before removal.
+	unmanaged := filepath.Join(tempDir, "/etc/microshift/manifests.d/app/unmanaged.txt")
+	require.NoError(os.WriteFile(unmanaged, []byte("keep me"), 0o600))
+
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, managed)},
+		&v1beta1.DeviceSpec{},
+	))
+
+	_, err := os.Stat(filepath.Join(tempDir, managed))
+	require.True(os.IsNotExist(err), "managed file should be removed")
+	_, err = os.Stat(unmanaged)
+	require.NoError(err, "unmanaged file must be preserved")
+	_, err = os.Stat(filepath.Join(tempDir, "/etc/microshift/manifests.d/app"))
+	require.NoError(err, "directory holding unmanaged content must not be removed")
+}
+
+func TestRemoveEmptyDirs(t *testing.T) {
+	tests := []struct {
+		name         string
+		removedFiles []string
+		desiredFiles []v1beta1.FileSpec
+		// expectedDirs is the exact set of directories RemoveEmptyDir is called
+		// with, in deepest-first order.
+		expectedDirs []string
+	}{
+		{
+			name: "nested tree cleaned deepest first, stops at /etc",
+			removedFiles: []string{
+				"/etc/microshift/manifests.d/app1/deploy.yaml",
+				"/etc/microshift/manifests.d/app2/svc.yaml",
+			},
+			expectedDirs: []string{
+				"/etc/microshift/manifests.d/app1",
+				"/etc/microshift/manifests.d/app2",
+				"/etc/microshift/manifests.d",
+				"/etc/microshift",
+			},
+		},
+		{
+			name: "directories holding desired files are preserved",
+			removedFiles: []string{
+				"/etc/microshift/manifests.d/app/remove.yaml",
+			},
+			desiredFiles: []v1beta1.FileSpec{
+				{Path: "/etc/microshift/manifests.d/app/keep.yaml"},
+			},
+			expectedDirs: nil,
+		},
+		{
+			name: "protected root is never removed",
+			removedFiles: []string{
+				"/etc/motd",
+			},
+			expectedDirs: nil,
+		},
+		{
+			name:         "empty removal list is a no-op",
+			removedFiles: nil,
+			expectedDirs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockWriter := fileio.NewMockWriter(ctrl)
+			var got []string
+			mockWriter.EXPECT().RemoveEmptyDir(gomock.Any()).DoAndReturn(func(dir string) error {
+				got = append(got, dir)
+				return nil
+			}).AnyTimes()
+
+			controller := NewController(mockWriter, log.NewPrefixLogger("test"))
+			controller.removeEmptyDirs(tt.removedFiles, tt.desiredFiles)
+
+			require.Equal(t, tt.expectedDirs, got)
+		})
+	}
+}
+
+func TestIsCleanupCandidate(t *testing.T) {
+	tests := []struct {
+		dir  string
+		want bool
+	}{
+		{"", false},
+		{".", false},
+		{"/", false},
+		{"/etc", false},
+		{"/var", false},
+		{"/etc/microshift", true},
+		{"/etc/microshift/manifests.d", true},
+		{"/opt/app/data", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dir, func(t *testing.T) {
+			require.Equal(t, tt.want, isCleanupCandidate(tt.dir))
+		})
+	}
+}

--- a/internal/agent/device/config/removal_test.go
+++ b/internal/agent/device/config/removal_test.go
@@ -51,7 +51,7 @@ func TestSyncRemovesEmptyDirs(t *testing.T) {
 		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
 		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
 	)
-	controller := NewController(rw, log.NewPrefixLogger("test"))
+	controller := NewController(rw, "/var/lib/flightctl", log.NewPrefixLogger("test"))
 
 	files := []string{
 		"/etc/microshift/manifests.d/app1/kustomization.yaml",
@@ -104,7 +104,7 @@ func TestSyncPreservesSharedDirs(t *testing.T) {
 		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
 		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
 	)
-	controller := NewController(rw, log.NewPrefixLogger("test"))
+	controller := NewController(rw, "/var/lib/flightctl", log.NewPrefixLogger("test"))
 
 	kept := "/etc/microshift/manifests.d/app/keep.yaml"
 	removed := "/etc/microshift/manifests.d/app/remove.yaml"
@@ -138,7 +138,7 @@ func TestSyncPreservesNonEmptyDirs(t *testing.T) {
 		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
 		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
 	)
-	controller := NewController(rw, log.NewPrefixLogger("test"))
+	controller := NewController(rw, "/var/lib/flightctl", log.NewPrefixLogger("test"))
 
 	managed := "/etc/microshift/manifests.d/app/managed.yaml"
 	require.NoError(controller.Sync(ctx,
@@ -163,11 +163,98 @@ func TestSyncPreservesNonEmptyDirs(t *testing.T) {
 	require.NoError(err, "directory holding unmanaged content must not be removed")
 }
 
+// TestSyncPreservesPreExistingDirs verifies end-to-end that cleanup removes only
+// directories the agent created: a pre-existing (e.g. package-created) directory
+// whose only file was a managed one is preserved once that file is removed,
+// while a sibling directory the agent created is pruned.
+func TestSyncPreservesPreExistingDirs(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	rw := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
+	)
+	controller := NewController(rw, "/var/lib/flightctl", log.NewPrefixLogger("test"))
+
+	// Simulate a package-created directory the agent must never remove.
+	preExisting := "/opt/vendor/data"
+	require.NoError(os.MkdirAll(filepath.Join(tempDir, preExisting), 0o755))
+
+	inPreExisting := "/opt/vendor/data/app.conf" // only file, but dir predates the agent
+	agentOwned := "/opt/managed/app/config.yaml" // agent creates /opt/managed[/app]
+
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{},
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, inPreExisting, agentOwned)},
+	))
+
+	// Remove the source.
+	require.NoError(controller.Sync(ctx,
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, inPreExisting, agentOwned)},
+		&v1beta1.DeviceSpec{},
+	))
+
+	// Both files are gone.
+	for _, f := range []string{inPreExisting, agentOwned} {
+		_, err := os.Stat(filepath.Join(tempDir, f))
+		require.True(os.IsNotExist(err), "file should be removed: %s", f)
+	}
+	// The pre-existing directory (and its parent) must survive.
+	_, err := os.Stat(filepath.Join(tempDir, preExisting))
+	require.NoError(err, "pre-existing directory the agent did not create must be preserved")
+	// The agent-created tree must be pruned.
+	for _, dir := range []string{"/opt/managed/app", "/opt/managed"} {
+		_, err := os.Stat(filepath.Join(tempDir, dir))
+		require.True(os.IsNotExist(err), "agent-created empty directory should be removed: %s", dir)
+	}
+}
+
+// TestSyncOwnershipPersistsAcrossControllers verifies that directory ownership
+// recorded when files are written survives into a fresh controller (simulating
+// an agent restart between the write and the later removal), so cleanup still
+// prunes the agent-created tree.
+func TestSyncOwnershipPersistsAcrossControllers(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	rw := fileio.NewReadWriter(
+		fileio.NewReader(fileio.WithReaderRootDir(tempDir)),
+		fileio.NewWriter(fileio.WithWriterRootDir(tempDir)),
+	)
+
+	file := "/etc/foo/bar/x.yaml"
+
+	// First controller writes the files and persists ownership.
+	writer := NewController(rw, "/var/lib/flightctl", log.NewPrefixLogger("test"))
+	require.NoError(writer.Sync(ctx,
+		&v1beta1.DeviceSpec{},
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, file)},
+	))
+
+	// A fresh controller (as after a reboot) removes the source.
+	remover := NewController(rw, "/var/lib/flightctl", log.NewPrefixLogger("test"))
+	require.NoError(remover.Sync(ctx,
+		&v1beta1.DeviceSpec{Config: inlineProvider(t, file)},
+		&v1beta1.DeviceSpec{},
+	))
+
+	for _, dir := range []string{"/etc/foo/bar", "/etc/foo"} {
+		_, err := os.Stat(filepath.Join(tempDir, dir))
+		require.True(os.IsNotExist(err), "agent-created empty directory should be removed after restart: %s", dir)
+	}
+	_, err := os.Stat(filepath.Join(tempDir, "/etc"))
+	require.NoError(err, "/etc must not be removed")
+}
+
 func TestRemoveEmptyDirs(t *testing.T) {
 	tests := []struct {
 		name         string
 		removedFiles []string
 		desiredFiles []v1beta1.FileSpec
+		// owned is the set of agent-created directories loaded from the ownership
+		// manifest; only directories in this set are eligible for cleanup.
+		owned []string
 		// expectedDirs is the exact set of directories RemoveEmptyDir is called
 		// with, in deepest-first order.
 		expectedDirs []string
@@ -177,6 +264,12 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			removedFiles: []string{
 				"/etc/microshift/manifests.d/app1/deploy.yaml",
 				"/etc/microshift/manifests.d/app2/svc.yaml",
+			},
+			owned: []string{
+				"/etc/microshift",
+				"/etc/microshift/manifests.d",
+				"/etc/microshift/manifests.d/app1",
+				"/etc/microshift/manifests.d/app2",
 			},
 			expectedDirs: []string{
 				"/etc/microshift/manifests.d/app1",
@@ -193,6 +286,11 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			desiredFiles: []v1beta1.FileSpec{
 				{Path: "/etc/microshift/manifests.d/app/keep.yaml"},
 			},
+			owned: []string{
+				"/etc/microshift",
+				"/etc/microshift/manifests.d",
+				"/etc/microshift/manifests.d/app",
+			},
 			expectedDirs: nil,
 		},
 		{
@@ -200,6 +298,7 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			removedFiles: []string{
 				"/etc/motd",
 			},
+			owned:        []string{"/etc"},
 			expectedDirs: nil,
 		},
 		{
@@ -207,11 +306,22 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			removedFiles: []string{
 				"/media/config/app.yaml",
 			},
+			owned: []string{"/media", "/media/config"},
 			// /media/config is cleaned, but /media (a direct child of "/") is
 			// preserved even though it is not on any allowlist.
 			expectedDirs: []string{
 				"/media/config",
 			},
+		},
+		{
+			name: "directories the agent did not create are never removed",
+			removedFiles: []string{
+				"/home/flightctl/.local/app.conf",
+			},
+			// The agent never created ~flightctl/.local (the package did), so it
+			// is absent from the owned set and must be preserved even once empty.
+			owned:        nil,
+			expectedDirs: nil,
 		},
 		{
 			name:         "empty removal list is a no-op",
@@ -225,15 +335,20 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockWriter := fileio.NewMockWriter(ctrl)
+			mockWriter := fileio.NewMockReadWriter(ctrl)
 			var got []string
 			mockWriter.EXPECT().RemoveEmptyDir(gomock.Any()).DoAndReturn(func(dir string) error {
 				got = append(got, dir)
 				return nil
 			}).AnyTimes()
 
-			controller := NewController(mockWriter, log.NewPrefixLogger("test"))
-			controller.removeEmptyDirs(tt.removedFiles, tt.desiredFiles)
+			owned := make(map[string]bool, len(tt.owned))
+			for _, dir := range tt.owned {
+				owned[dir] = true
+			}
+
+			controller := NewController(mockWriter, "/var/lib/flightctl", log.NewPrefixLogger("test"))
+			controller.removeEmptyDirs(tt.removedFiles, tt.desiredFiles, owned)
 
 			require.Equal(t, tt.expectedDirs, got)
 		})

--- a/internal/agent/device/config/removal_test.go
+++ b/internal/agent/device/config/removal_test.go
@@ -204,6 +204,17 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			expectedDirs: nil,
 		},
 		{
+			name: "unlisted top-level dir is never removed, nested dirs are",
+			removedFiles: []string{
+				"/media/config/app.yaml",
+			},
+			// /media/config is cleaned, but /media (a direct child of "/") is
+			// preserved even though it is not on any allowlist.
+			expectedDirs: []string{
+				"/media/config",
+			},
+		},
+		{
 			name:         "empty removal list is a no-op",
 			removedFiles: nil,
 			expectedDirs: nil,
@@ -243,6 +254,11 @@ func TestIsCleanupCandidate(t *testing.T) {
 		{"/etc/microshift", true},
 		{"/etc/microshift/manifests.d", true},
 		{"/opt/app/data", true},
+		// top-level directories (direct children of "/") are never candidates,
+		// even ones not on any allowlist such as /media or /lib64.
+		{"/media", false},
+		{"/lib64", false},
+		{"/media/app", true},
 		// relative paths must never be cleanup candidates: joined with the
 		// writer root they could traverse outside it (e.g. "../etc").
 		{"../etc", false},

--- a/internal/agent/device/config/removal_test.go
+++ b/internal/agent/device/config/removal_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -337,9 +338,9 @@ func TestRemoveEmptyDirs(t *testing.T) {
 
 			mockWriter := fileio.NewMockReadWriter(ctrl)
 			var got []string
-			mockWriter.EXPECT().RemoveEmptyDir(gomock.Any()).DoAndReturn(func(dir string) error {
+			mockWriter.EXPECT().RemoveEmptyDir(gomock.Any()).DoAndReturn(func(dir string) (bool, error) {
 				got = append(got, dir)
-				return nil
+				return true, nil
 			}).AnyTimes()
 
 			owned := make(map[string]bool, len(tt.owned))
@@ -353,6 +354,56 @@ func TestRemoveEmptyDirs(t *testing.T) {
 			require.Equal(t, tt.expectedDirs, got)
 		})
 	}
+}
+
+// TestRemoveEmptyDirsOwnership verifies how ownership is updated after the
+// best-effort removal attempt: a directory that was removed or merely preserved
+// (RemoveEmptyDir reported no error) is relinquished, while one whose removal
+// errored keeps its ownership so the next reconcile retries.
+func TestRemoveEmptyDirsOwnership(t *testing.T) {
+	const (
+		removedDir   = "/etc/app/removed"   // RemoveEmptyDir reports removed=true
+		preservedDir = "/etc/app/preserved" // RemoveEmptyDir reports removed=false (e.g. unmanaged content)
+		erroredDir   = "/etc/app/errored"   // RemoveEmptyDir returns an error
+	)
+	removedFiles := []string{
+		removedDir + "/a.yaml",
+		preservedDir + "/b.yaml",
+		erroredDir + "/c.yaml",
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWriter := fileio.NewMockReadWriter(ctrl)
+	mockWriter.EXPECT().RemoveEmptyDir(gomock.Any()).DoAndReturn(func(dir string) (bool, error) {
+		switch dir {
+		case removedDir:
+			return true, nil
+		case erroredDir:
+			return false, errors.New("boom")
+		default:
+			// preservedDir and the shared /etc/app parent: no error, not removed.
+			return false, nil
+		}
+	}).AnyTimes()
+
+	owned := map[string]bool{
+		removedDir:   true,
+		preservedDir: true,
+		erroredDir:   true,
+		"/etc/app":   true,
+	}
+
+	controller := NewController(mockWriter, "/var/lib/flightctl", log.NewPrefixLogger("test"))
+	changed := controller.removeEmptyDirs(removedFiles, nil, owned)
+
+	require.True(t, changed)
+	// Removed and preserved directories are both relinquished after the attempt.
+	require.NotContains(t, owned, removedDir)
+	require.NotContains(t, owned, preservedDir)
+	// A directory whose removal errored keeps its ownership for a later retry.
+	require.Contains(t, owned, erroredDir)
 }
 
 func TestIsCleanupCandidate(t *testing.T) {

--- a/internal/agent/device/config/removal_test.go
+++ b/internal/agent/device/config/removal_test.go
@@ -40,11 +40,10 @@ func inlineProvider(t *testing.T, paths ...string) *[]v1beta1.ConfigProviderSpec
 	return &[]v1beta1.ConfigProviderSpec{provider}
 }
 
-// TestSyncRemovesEmptyDirs_EDM4892 reproduces the reported scenario end-to-end
-// with a real writer: a host configuration (e.g. MicroShift manifests from a
-// git repo) populates a nested directory tree, then the source is removed. Both
-// the files and the directories created to hold them must be gone afterwards.
-func TestSyncRemovesEmptyDirs_EDM4892(t *testing.T) {
+// TestSyncRemovesEmptyDirs verifies end-to-end with a real writer that removing
+// a config source deletes both its files and the now-empty directory tree that
+// held them, while a protected system root survives.
+func TestSyncRemovesEmptyDirs(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
 	tempDir := t.TempDir()

--- a/internal/agent/device/device_test.go
+++ b/internal/agent/device/device_test.go
@@ -406,7 +406,7 @@ func TestSync(t *testing.T) {
 			appController := applications.NewController(podmanFactory, nil, mockAppManager, rwFactory, log, "2025-01-01T00:00:00Z")
 			statusManager := status.NewManager(deviceName, log)
 			statusManager.SetClient(mockManagementClient)
-			configController := config.NewController(readWriter, log)
+			configController := config.NewController(readWriter, tempDir, log)
 
 			agent := Agent{
 				log:                    log,
@@ -963,7 +963,7 @@ func TestSyncDeviceSpecPackageModeRejection(t *testing.T) {
 		}
 		consoleManager := console.NewManager(nil, deviceName, "root", mockExec, mockWatcher, logger)
 		appController := applications.NewController(podmanFactory, nil, mockAppManager, rwFactory, logger, "2025-01-01T00:00:00Z")
-		configController := config.NewController(readWriter, logger)
+		configController := config.NewController(readWriter, tempDir, logger)
 
 		upgradeFailed := false
 		rollbackCalled := false

--- a/internal/agent/device/fileio/fileio.go
+++ b/internal/agent/device/fileio/fileio.go
@@ -33,6 +33,9 @@ type Writer interface {
 	WriteFile(name string, data []byte, perm fs.FileMode, opts ...FileOption) error
 	// RemoveFile removes the file at the given path
 	RemoveFile(file string) error
+	// RemoveEmptyDir removes the directory at the given path only if it is empty.
+	// It is a no-op if the directory does not exist or still contains entries.
+	RemoveEmptyDir(dir string) error
 	// RemoveAll removes the file or directory at the given path
 	RemoveAll(path string) error
 	// Rename renames (moves) oldpath to newpath

--- a/internal/agent/device/fileio/fileio.go
+++ b/internal/agent/device/fileio/fileio.go
@@ -33,9 +33,11 @@ type Writer interface {
 	WriteFile(name string, data []byte, perm fs.FileMode, opts ...FileOption) error
 	// RemoveFile removes the file at the given path
 	RemoveFile(file string) error
-	// RemoveEmptyDir removes the directory at the given path only if it is empty.
-	// It is a no-op if the directory does not exist or still contains entries.
-	RemoveEmptyDir(dir string) error
+	// RemoveEmptyDir removes the directory at the given path only if it is empty,
+	// reporting whether it was actually removed. It is a no-op (removed=false) if
+	// the directory does not exist, is a symlink or non-directory, or still
+	// contains entries.
+	RemoveEmptyDir(dir string) (bool, error)
 	// RemoveAll removes the file or directory at the given path
 	RemoveAll(path string) error
 	// Rename renames (moves) oldpath to newpath

--- a/internal/agent/device/fileio/mock_fileio.go
+++ b/internal/agent/device/fileio/mock_fileio.go
@@ -270,6 +270,20 @@ func (mr *MockWriterMockRecorder) RemoveContents(path any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContents", reflect.TypeOf((*MockWriter)(nil).RemoveContents), path)
 }
 
+// RemoveEmptyDir mocks base method.
+func (m *MockWriter) RemoveEmptyDir(dir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveEmptyDir", dir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveEmptyDir indicates an expected call of RemoveEmptyDir.
+func (mr *MockWriterMockRecorder) RemoveEmptyDir(dir any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEmptyDir", reflect.TypeOf((*MockWriter)(nil).RemoveEmptyDir), dir)
+}
+
 // RemoveFile mocks base method.
 func (m *MockWriter) RemoveFile(file string) error {
 	m.ctrl.T.Helper()
@@ -623,6 +637,20 @@ func (m *MockReadWriter) RemoveContents(path string) error {
 func (mr *MockReadWriterMockRecorder) RemoveContents(path any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContents", reflect.TypeOf((*MockReadWriter)(nil).RemoveContents), path)
+}
+
+// RemoveEmptyDir mocks base method.
+func (m *MockReadWriter) RemoveEmptyDir(dir string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveEmptyDir", dir)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveEmptyDir indicates an expected call of RemoveEmptyDir.
+func (mr *MockReadWriterMockRecorder) RemoveEmptyDir(dir any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEmptyDir", reflect.TypeOf((*MockReadWriter)(nil).RemoveEmptyDir), dir)
 }
 
 // RemoveFile mocks base method.

--- a/internal/agent/device/fileio/mock_fileio.go
+++ b/internal/agent/device/fileio/mock_fileio.go
@@ -271,11 +271,12 @@ func (mr *MockWriterMockRecorder) RemoveContents(path any) *gomock.Call {
 }
 
 // RemoveEmptyDir mocks base method.
-func (m *MockWriter) RemoveEmptyDir(dir string) error {
+func (m *MockWriter) RemoveEmptyDir(dir string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveEmptyDir", dir)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RemoveEmptyDir indicates an expected call of RemoveEmptyDir.
@@ -640,11 +641,12 @@ func (mr *MockReadWriterMockRecorder) RemoveContents(path any) *gomock.Call {
 }
 
 // RemoveEmptyDir mocks base method.
-func (m *MockReadWriter) RemoveEmptyDir(dir string) error {
+func (m *MockReadWriter) RemoveEmptyDir(dir string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveEmptyDir", dir)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // RemoveEmptyDir indicates an expected call of RemoveEmptyDir.

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -167,6 +167,20 @@ func (w *writer) RemoveFile(file string) error {
 // it never deletes directories that hold other content.
 func (w *writer) RemoveEmptyDir(dir string) error {
 	fullPath := filepath.Join(w.rootDir, dir)
+	// Only operate on real directories. os.Open would follow a symlink and read
+	// its target, but os.Remove would delete the link and leave the target in
+	// place; skip symlinks (and anything that is not a directory) so cleanup only
+	// removes actual, owned directories.
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat dir %q: %w", dir, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil
+	}
 	// Only one entry is needed to decide the directory is non-empty; reading a
 	// single entry avoids listing and sorting every entry, which matters on
 	// constrained edge devices where the directory may hold many unmanaged files.

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -191,14 +191,16 @@ func (w *writer) RemoveEmptyDir(dir string) error {
 		}
 		return fmt.Errorf("open dir %q: %w", dir, err)
 	}
-	_, err = f.ReadDir(1)
-	f.Close()
-	if err == nil {
+	_, readErr := f.ReadDir(1)
+	if closeErr := f.Close(); closeErr != nil {
+		return fmt.Errorf("close dir %q: %w", dir, closeErr)
+	}
+	if readErr == nil {
 		// directory still holds content; leave it in place
 		return nil
 	}
-	if err != io.EOF {
-		return fmt.Errorf("read dir %q: %w", dir, err)
+	if readErr != io.EOF {
+		return fmt.Errorf("read dir %q: %w", dir, readErr)
 	}
 	if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove empty dir %q: %w", dir, err)

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -162,6 +162,28 @@ func (w *writer) RemoveFile(file string) error {
 	return nil
 }
 
+// RemoveEmptyDir removes the directory at the given path only if it is empty.
+// It is a no-op if the directory does not exist or still contains entries, so
+// it never deletes directories that hold other content.
+func (w *writer) RemoveEmptyDir(dir string) error {
+	fullPath := filepath.Join(w.rootDir, dir)
+	entries, err := os.ReadDir(fullPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read dir %q: %w", dir, err)
+	}
+	if len(entries) > 0 {
+		// directory still holds content; leave it in place
+		return nil
+	}
+	if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove empty dir %q: %w", dir, err)
+	}
+	return nil
+}
+
 func (w *writer) RemoveAll(path string) error {
 	if err := os.RemoveAll(filepath.Join(w.rootDir, path)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove path %q: %w", path, err)

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -162,10 +162,11 @@ func (w *writer) RemoveFile(file string) error {
 	return nil
 }
 
-// RemoveEmptyDir removes the directory at the given path only if it is empty.
-// It is a no-op if the directory does not exist or still contains entries, so
-// it never deletes directories that hold other content.
-func (w *writer) RemoveEmptyDir(dir string) error {
+// RemoveEmptyDir removes the directory at the given path only if it is empty,
+// reporting whether it was actually removed. It is a no-op (removed=false) if the
+// directory does not exist, is a symlink or non-directory, or still contains
+// entries, so it never deletes directories that hold other content.
+func (w *writer) RemoveEmptyDir(dir string) (bool, error) {
 	fullPath := filepath.Join(w.rootDir, dir)
 	// Only operate on real directories. os.Open would follow a symlink and read
 	// its target, but os.Remove would delete the link and leave the target in
@@ -174,12 +175,12 @@ func (w *writer) RemoveEmptyDir(dir string) error {
 	info, err := os.Lstat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("stat dir %q: %w", dir, err)
+		return false, fmt.Errorf("stat dir %q: %w", dir, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-		return nil
+		return false, nil
 	}
 	// Only one entry is needed to decide the directory is non-empty; reading a
 	// single entry avoids listing and sorting every entry, which matters on
@@ -187,25 +188,28 @@ func (w *writer) RemoveEmptyDir(dir string) error {
 	f, err := os.Open(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("open dir %q: %w", dir, err)
+		return false, fmt.Errorf("open dir %q: %w", dir, err)
 	}
 	_, readErr := f.ReadDir(1)
 	if closeErr := f.Close(); closeErr != nil {
-		return fmt.Errorf("close dir %q: %w", dir, closeErr)
+		return false, fmt.Errorf("close dir %q: %w", dir, closeErr)
 	}
 	if readErr == nil {
 		// directory still holds content; leave it in place
-		return nil
+		return false, nil
 	}
 	if readErr != io.EOF {
-		return fmt.Errorf("read dir %q: %w", dir, readErr)
+		return false, fmt.Errorf("read dir %q: %w", dir, readErr)
 	}
-	if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove empty dir %q: %w", dir, err)
+	if err := os.Remove(fullPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("remove empty dir %q: %w", dir, err)
 	}
-	return nil
+	return true, nil
 }
 
 func (w *writer) RemoveAll(path string) error {

--- a/internal/agent/device/fileio/writer.go
+++ b/internal/agent/device/fileio/writer.go
@@ -167,16 +167,24 @@ func (w *writer) RemoveFile(file string) error {
 // it never deletes directories that hold other content.
 func (w *writer) RemoveEmptyDir(dir string) error {
 	fullPath := filepath.Join(w.rootDir, dir)
-	entries, err := os.ReadDir(fullPath)
+	// Only one entry is needed to decide the directory is non-empty; reading a
+	// single entry avoids listing and sorting every entry, which matters on
+	// constrained edge devices where the directory may hold many unmanaged files.
+	f, err := os.Open(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("read dir %q: %w", dir, err)
+		return fmt.Errorf("open dir %q: %w", dir, err)
 	}
-	if len(entries) > 0 {
+	_, err = f.ReadDir(1)
+	f.Close()
+	if err == nil {
 		// directory still holds content; leave it in place
 		return nil
+	}
+	if err != io.EOF {
+		return fmt.Errorf("read dir %q: %w", dir, err)
 	}
 	if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove empty dir %q: %w", dir, err)

--- a/internal/agent/device/fileio/writer_test.go
+++ b/internal/agent/device/fileio/writer_test.go
@@ -623,8 +623,9 @@ func TestRemoveEmptyDir(t *testing.T) {
 		name string
 		// setup prepares the directory tree under rootDir and returns the
 		// relative path passed to RemoveEmptyDir.
-		setup      func(t *testing.T, rootDir string) string
-		wantExists bool
+		setup       func(t *testing.T, rootDir string) string
+		wantRemoved bool
+		wantExists  bool
 	}{
 		{
 			name: "When the directory is empty it should be removed",
@@ -632,7 +633,8 @@ func TestRemoveEmptyDir(t *testing.T) {
 				require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "empty"), 0755))
 				return "empty"
 			},
-			wantExists: false,
+			wantRemoved: true,
+			wantExists:  false,
 		},
 		{
 			name: "When the directory still holds an entry it should be preserved",
@@ -641,14 +643,16 @@ func TestRemoveEmptyDir(t *testing.T) {
 				require.NoError(t, os.WriteFile(filepath.Join(rootDir, "full", "keep.txt"), []byte("x"), 0600))
 				return "full"
 			},
-			wantExists: true,
+			wantRemoved: false,
+			wantExists:  true,
 		},
 		{
 			name: "When the directory does not exist it should be a no-op",
 			setup: func(t *testing.T, rootDir string) string {
 				return "missing"
 			},
-			wantExists: false,
+			wantRemoved: false,
+			wantExists:  false,
 		},
 		{
 			name: "When the path is a symlink to an empty directory it should be preserved",
@@ -657,7 +661,17 @@ func TestRemoveEmptyDir(t *testing.T) {
 				require.NoError(t, os.Symlink(filepath.Join(rootDir, "target"), filepath.Join(rootDir, "link")))
 				return "link"
 			},
-			wantExists: true,
+			wantRemoved: false,
+			wantExists:  true,
+		},
+		{
+			name: "When the path is a regular file it should be preserved",
+			setup: func(t *testing.T, rootDir string) string {
+				require.NoError(t, os.WriteFile(filepath.Join(rootDir, "file.txt"), []byte("x"), 0600))
+				return "file.txt"
+			},
+			wantRemoved: false,
+			wantExists:  true,
 		},
 	}
 
@@ -668,9 +682,11 @@ func TestRemoveEmptyDir(t *testing.T) {
 			dir := tt.setup(t, rootDir)
 
 			w := NewWriter(WithWriterRootDir(rootDir))
-			require.NoError(w.RemoveEmptyDir(dir))
+			removed, err := w.RemoveEmptyDir(dir)
+			require.NoError(err)
+			require.Equal(tt.wantRemoved, removed)
 
-			_, err := os.Stat(filepath.Join(rootDir, dir))
+			_, err = os.Stat(filepath.Join(rootDir, dir))
 			if tt.wantExists {
 				require.NoError(err)
 			} else {

--- a/internal/agent/device/fileio/writer_test.go
+++ b/internal/agent/device/fileio/writer_test.go
@@ -617,3 +617,56 @@ func TestWriterForUser(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "chown")
 }
+
+func TestRemoveEmptyDir(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup prepares the directory tree under rootDir and returns the
+		// relative path passed to RemoveEmptyDir.
+		setup      func(t *testing.T, rootDir string) string
+		wantExists bool
+	}{
+		{
+			name: "When the directory is empty it should be removed",
+			setup: func(t *testing.T, rootDir string) string {
+				require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "empty"), 0755))
+				return "empty"
+			},
+			wantExists: false,
+		},
+		{
+			name: "When the directory still holds an entry it should be preserved",
+			setup: func(t *testing.T, rootDir string) string {
+				require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "full"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(rootDir, "full", "keep.txt"), []byte("x"), 0600))
+				return "full"
+			},
+			wantExists: true,
+		},
+		{
+			name: "When the directory does not exist it should be a no-op",
+			setup: func(t *testing.T, rootDir string) string {
+				return "missing"
+			},
+			wantExists: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			rootDir := t.TempDir()
+			dir := tt.setup(t, rootDir)
+
+			w := NewWriter(WithWriterRootDir(rootDir))
+			require.NoError(w.RemoveEmptyDir(dir))
+
+			_, err := os.Stat(filepath.Join(rootDir, dir))
+			if tt.wantExists {
+				require.NoError(err)
+			} else {
+				require.True(os.IsNotExist(err))
+			}
+		})
+	}
+}

--- a/internal/agent/device/fileio/writer_test.go
+++ b/internal/agent/device/fileio/writer_test.go
@@ -650,6 +650,15 @@ func TestRemoveEmptyDir(t *testing.T) {
 			},
 			wantExists: false,
 		},
+		{
+			name: "When the path is a symlink to an empty directory it should be preserved",
+			setup: func(t *testing.T, rootDir string) string {
+				require.NoError(t, os.MkdirAll(filepath.Join(rootDir, "target"), 0755))
+				require.NoError(t, os.Symlink(filepath.Join(rootDir, "target"), filepath.Join(rootDir, "link")))
+				return "link"
+			},
+			wantExists: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Removing a host configuration source that created a directory tree on a device
(e.g. MicroShift manifests under `/etc/microshift/manifests.d/`) deleted the
files but left the now-empty directories behind. The stale, empty tree reads as
"configuration still present" (including to MicroShift's manifest scanner) and
diverges from the declared desired state, which blocks the RHEM-with-MicroShift
workflow the reporter described.

This PR extends the agent's config reconcile to prune directories that become
empty as a result of removing obsolete files.

## Root Cause

The server render captures only `ignition.Storage.Files` and drops
`Storage.Directories` (`internal/tasks/device_render.go:988`,
`ignitionConfigToRenderedConfig`, which loops solely over `Storage.Files`).
Directories are created implicitly on write, but
`config.Controller.removeObsoleteFiles` removes files via
`fileio.Writer.RemoveFile` (a plain file remove) and never removes the
directories created to hold them. File *contents* are removed correctly; only
the empty directory tree lingers.

## Fix

- Add `RemoveEmptyDir` to `fileio.Writer` — removes a directory **only if it is
  empty**, and is a no-op if the directory is missing or still holds entries.
- After deleting obsolete files, `removeObsoleteFiles` walks each removed file's
  ancestor directories **deepest-first** and removes those now empty, with:
  - a protected-roots allowlist (`/`, `/etc`, `/var`, `/usr`, …) never removed;
  - preservation of every directory that still holds a *desired* file;
  - best-effort semantics — cleanup failures are logged, never fatal to the
    reconcile.

## Before / After

Given a source populating:

```
/etc/microshift/manifests.d/app1/deploy.yaml
/etc/microshift/manifests.d/app2/svc.yaml
```

then removing that source:

- **Before:** files deleted, but `/etc/microshift/manifests.d/{app1,app2}` and
  parents remain as empty directories.
- **After:** files deleted **and** the empty directory tree removed, up to (but
  never including) `/etc`.

## Testing

- `TestSyncRemovesEmptyDirs_EDM4892` — end-to-end with a real writer; **verified
  to fail without the fix and pass with it**.
- `TestSyncPreservesSharedDirs` — a directory holding a remaining desired file
  is kept.
- `TestSyncPreservesNonEmptyDirs` — a directory holding unmanaged content is
  kept (real unmanaged file written to disk).
- `TestRemoveEmptyDirs`, `TestIsCleanupCandidate` — ordering, protected roots,
  kept dirs, edge cases.
- `make lint` clean (0 issues); full unit suite passes (one unrelated,
  environment-specific failure in `internal/backup` caused by a local
  `/etc/flightctl/service-config.yaml` — see Known Issues).

## Manual testing for reviewers

Apply a host config that creates a nested tree under `/etc`, confirm the files
land, remove the source, and confirm the files and empty directories are gone
while `/etc` and any sibling/unmanaged content remain.

## Confidence

HIGH — the fix targets the confirmed root cause at the agent reconcile boundary;
the regression test is proven non-tautological; safety guards (empty-only
removal, protected roots, desired-ancestor preservation) are each covered by a
real-writer test. The reporter confirmed on 1.3.0-main (2026-08-27) that files
are removed but empty directories remain, matching exactly what this addresses.

## Rollback

Safe to revert. The change is additive (`RemoveEmptyDir` on the `Writer`
interface plus one call site and two helpers); reverting restores prior behavior
with no migration, config, API, or on-disk format impact.

## Risk Assessment

LOW — directory removal only ever touches empty directories outside a protected
allowlist and outside the ancestors of desired files, honors the writer
`rootDir`, and is best-effort/non-fatal, so it cannot delete operator data,
system directories, or fail a config sync.

## Known Issues

- The `internal/backup TestPodmanDeployer_BackupConfig` failure is environmental
  (the test assumes `/etc/flightctl/service-config.yaml` is absent) and is
  unrelated to this change; it passes in CI.

Fixes EDM-4892
