### PR TITLE
NO-ISSUE: Resolve package-mode enrollment host in Podman

### DIFF
--- a/test/harness/e2e/package_mode_agent.go
+++ b/test/harness/e2e/package_mode_agent.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,11 +16,13 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
+	agentcfg "github.com/flightctl/flightctl/internal/agent/config"
 	"github.com/flightctl/flightctl/test/harness/containers"
 	testutil "github.com/flightctl/flightctl/test/util"
 	"github.com/sirupsen/logrus"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -67,6 +71,18 @@ func StartPackageModeAgent(ctx context.Context, agentConfigDir, registryHost, re
 	}
 	if _, err := os.Stat(agentCertsDir); err != nil {
 		return nil, fmt.Errorf("agent certs dir not found at %s: %w", agentCertsDir, err)
+	}
+	var enrollmentHostMapping string
+	if containers.IsPodman() && isK8sEnvironment() {
+		enrollmentServer, err := enrollmentServerFromConfig(agentConfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("read package-mode enrollment server: %w", err)
+		}
+		resolvedHostMapping, err := enrollmentHostMappingFromServer(ctx, enrollmentServer, net.DefaultResolver.LookupIP)
+		if err != nil {
+			return nil, fmt.Errorf("resolve package-mode enrollment host: %w", err)
+		}
+		enrollmentHostMapping = resolvedHostMapping
 	}
 
 	files := []testcontainers.ContainerFile{
@@ -117,6 +133,9 @@ func StartPackageModeAgent(ctx context.Context, agentConfigDir, registryHost, re
 			)
 			if containers.IsPodman() {
 				hc.ExtraHosts = append(hc.ExtraHosts, "host.containers.internal:host-gateway")
+				if enrollmentHostMapping != "" {
+					hc.ExtraHosts = append(hc.ExtraHosts, enrollmentHostMapping)
+				}
 			}
 		},
 	}
@@ -153,6 +172,48 @@ func StartPackageModeAgent(ctx context.Context, agentConfigDir, registryHost, re
 
 	logrus.Info("Package-mode agent container started")
 	return agent, nil
+}
+
+// enrollmentServerFromConfig reads the enrollment service URL from a strictly validated agent config.
+func enrollmentServerFromConfig(configPath string) (string, error) {
+	contents, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", fmt.Errorf("read agent config: %w", err)
+	}
+
+	var config agentcfg.Config
+	if err := yaml.UnmarshalStrict(contents, &config); err != nil {
+		return "", fmt.Errorf("parse agent config: %w", err)
+	}
+
+	server := strings.TrimSpace(config.EnrollmentService.Service.Server)
+	if server == "" {
+		return "", fmt.Errorf("agent config does not define enrollment-service.service.server")
+	}
+	return server, nil
+}
+
+// enrollmentHostMappingFromServer resolves an enrollment server hostname into a container host mapping.
+func enrollmentHostMappingFromServer(ctx context.Context, server string, lookupIP func(context.Context, string, string) ([]net.IP, error)) (string, error) {
+	parsed, err := url.Parse(server)
+	if err != nil {
+		return "", fmt.Errorf("parse enrollment server URL: %w", err)
+	}
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return "", fmt.Errorf("enrollment server URL does not define a hostname")
+	}
+
+	ips, err := lookupIP(ctx, "ip4", hostname)
+	if err != nil {
+		return "", fmt.Errorf("resolve enrollment hostname %q: %w", hostname, err)
+	}
+	for _, ip := range ips {
+		if ipv4 := ip.To4(); ipv4 != nil {
+			return hostname + ":" + ipv4.String(), nil
+		}
+	}
+	return "", fmt.Errorf("enrollment hostname %q has no IPv4 address", hostname)
 }
 
 // setupContainerEnvironment prepares the package-mode helper container to run the agent and nested podman workloads.

--- a/test/harness/e2e/package_mode_agent_test.go
+++ b/test/harness/e2e/package_mode_agent_test.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnrollmentServerFromConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		content   string
+		want      string
+		wantError string
+	}{
+		{
+			name:    "When config uses an OCP enrollment endpoint it should return the endpoint",
+			content: "enrollment-service:\n  service:\n    server: https://agent-api.flightctl.apps.example.com\n",
+			want:    "https://agent-api.flightctl.apps.example.com",
+		},
+		{
+			name:    "When config uses a quadlet enrollment endpoint it should return the endpoint",
+			content: "enrollment-service:\n  service:\n    server: https://flightctl-vm.local:7443/\n",
+			want:    "https://flightctl-vm.local:7443/",
+		},
+		{
+			name:      "When config omits an enrollment endpoint it should return an error",
+			content:   "enrollment-service:\n  service: {}\n",
+			wantError: "does not define enrollment-service.service.server",
+		},
+		{
+			name:      "When config is malformed it should return an error",
+			content:   "enrollment-service: [\n",
+			wantError: "parse agent config",
+		},
+		{
+			name:      "When config contains an unknown field it should return an error",
+			content:   "enrollment-service:\n  service:\n    server: https://agent-api.flightctl.apps.example.com\nunexpected-field: true\n",
+			wantError: "parse agent config",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, os.WriteFile(configPath, []byte(test.content), 0o600))
+
+			got, err := enrollmentServerFromConfig(configPath)
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+
+	t.Run("When config file is missing it should return an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := enrollmentServerFromConfig(filepath.Join(t.TempDir(), "missing.yaml"))
+		require.ErrorContains(t, err, "read agent config")
+	})
+}
+
+func TestEnrollmentHostMappingFromServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		server             string
+		lookupIPs          []net.IP
+		lookupErr          error
+		wantLookupHostname string
+		wantLookupCall     bool
+		want               string
+		wantError          string
+	}{
+		{
+			name:               "When the enrollment host has an IPv4 address it should return a container host mapping",
+			server:             "https://agent-api.flightctl.apps.example.com/api/v1/enrollmentrequests",
+			lookupIPs:          []net.IP{net.ParseIP("192.168.130.10")},
+			wantLookupHostname: "agent-api.flightctl.apps.example.com",
+			wantLookupCall:     true,
+			want:               "agent-api.flightctl.apps.example.com:192.168.130.10",
+		},
+		{
+			name:               "When the enrollment host only has IPv6 it should return an error",
+			server:             "https://agent-api.flightctl.apps.example.com",
+			lookupIPs:          []net.IP{net.ParseIP("2001:db8::1")},
+			wantLookupHostname: "agent-api.flightctl.apps.example.com",
+			wantLookupCall:     true,
+			wantError:          "has no IPv4 address",
+		},
+		{
+			name:               "When the enrollment hostname cannot be resolved it should return an error",
+			server:             "https://agent-api.flightctl.apps.example.com",
+			lookupErr:          errors.New("lookup failed"),
+			wantLookupHostname: "agent-api.flightctl.apps.example.com",
+			wantLookupCall:     true,
+			wantError:          "resolve enrollment hostname",
+		},
+		{
+			name:      "When the enrollment server has no hostname it should return an error",
+			server:    "https:///api/v1/enrollmentrequests",
+			wantError: "does not define a hostname",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			lookupCalled := false
+			lookupIP := func(_ context.Context, network, hostname string) ([]net.IP, error) {
+				lookupCalled = true
+				if network != "ip4" {
+					t.Errorf("lookup network = %q, want ip4", network)
+				}
+				if hostname != test.wantLookupHostname {
+					t.Errorf("lookup hostname = %q, want %q", hostname, test.wantLookupHostname)
+				}
+				return test.lookupIPs, test.lookupErr
+			}
+
+			got, err := enrollmentHostMappingFromServer(context.Background(), test.server, lookupIP)
+			require.Equal(t, test.wantLookupCall, lookupCalled)
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The package-mode test container could not resolve the FlightCtl enrollment API hostname in OCP/ACM. The host running the test could resolve it, but rootless Podman inside the helper container timed out on DNS, so the agent could not enroll.

The fix reads the enrollment API hostname from the agent config, resolves it on the test host, and adds that hostname/IP mapping into the helper container. The agent still connects using the normal HTTPS hostname, so TLS behavior stays the same.

## Validation

[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
  > Enter [ReportAfterSuite] TOP-LEVEL - autogenerated by Ginkgo @ 09/01/26 16:08:12.121
  < Exit [ReportAfterSuite] TOP-LEVEL - autogenerated by Ginkgo @ 09/01/26 16:08:12.129 (8ms)
[ReportAfterSuite] PASSED [0.008 seconds]
------------------------------

Ran 1 of 3 Specs in 18.817 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 2 Skipped