### PR TITLE
EDM-5693: Use fixed nine-character Git hashes in build metadata

### DIFF
--- a/.github/actions/compute-tag/action.yaml
+++ b/.github/actions/compute-tag/action.yaml
@@ -44,7 +44,7 @@ runs:
         else
           SOURCE_GIT_TREE_STATE=dirty
         fi
-        SOURCE_GIT_COMMIT=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")
+        SOURCE_GIT_COMMIT=$( (git rev-parse "HEAD^{commit}" 2>/dev/null || echo "unknown") | cut -c1-9)
         
         {
           echo "git_tag=${SOURCE_GIT_TAG}"

--- a/.github/workflows/ppa-build.yaml
+++ b/.github/workflows/ppa-build.yaml
@@ -38,7 +38,7 @@ jobs:
 #       - name: Update changelog
 #         run: |
 #           FULL_DATE=$(date '+%a, %d %b %Y %H:%M:%S %z')
-#           DATE=$(date '+%Y.%m.%d.%s').$(git rev-parse --short HEAD)
+#           DATE=$(date '+%Y.%m.%d.%s').$(git rev-parse HEAD | cut -c1-9)
 #           {
 #             echo "flightctl ($DATE) jammy; urgency=medium";
 #             echo "";

--- a/.github/workflows/publish-containers.yaml
+++ b/.github/workflows/publish-containers.yaml
@@ -167,7 +167,7 @@ jobs:
           else
             SOURCE_GIT_TREE_STATE=dirty
           fi
-          SOURCE_GIT_COMMIT=$(git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")
+          SOURCE_GIT_COMMIT=$( (git rev-parse "HEAD^{commit}" 2>/dev/null || echo "unknown") | cut -c1-9)
 
           {
             echo "git_tag=${SOURCE_GIT_TAG}"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ VERBOSE ?= false
 
 SOURCE_GIT_TAG ?=$(shell $(ROOT_DIR)/hack/current-version)
 SOURCE_GIT_TREE_STATE ?=$(shell ( ( [ ! -d "$(ROOT_DIR)/.git/" ] || git -C $(ROOT_DIR) diff --quiet ) && echo 'clean' ) || echo 'dirty')
-SOURCE_GIT_COMMIT ?=$(shell git -C $(ROOT_DIR) rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")
+SOURCE_GIT_COMMIT ?=$(shell (git -C $(ROOT_DIR) rev-parse "HEAD^{commit}" 2>/dev/null || echo "unknown") | cut -c1-9)
 BIN_TIMESTAMP ?=$(shell date +'%Y%m%d')
 SOURCE_GIT_TAG_NO_V = $(shell echo $(SOURCE_GIT_TAG) | sed 's/^v//')
 MAJOR = $(shell echo $(SOURCE_GIT_TAG_NO_V) | awk -F'[._~-]' '{print $$1}')

--- a/hack/build_rpms.sh
+++ b/hack/build_rpms.sh
@@ -132,7 +132,7 @@ collect_git_worktree_mounts() {
 }
 
 current_commit() {
-  (cd "${REPO_ROOT}" && git rev-parse --short "HEAD^{commit}" 2>/dev/null) || echo "unknown"
+  ( (cd "${REPO_ROOT}" && git rev-parse "HEAD^{commit}" 2>/dev/null) || echo "unknown") | cut -c1-9
 }
 
 ensure_version_env() {

--- a/hack/current-version
+++ b/hack/current-version
@@ -19,7 +19,9 @@ tag=$(git -c "versionsort.suffix=-rc" tag --points-at HEAD --sort version:refnam
 # base commit and re-attach the distance and hash suffix.
 if [[ -z "$tag" ]]; then
   nearest_tag=$(git describe --tags --always --first-parent --match 'v*' --abbrev=0 2>/dev/null)
-  full_describe=$(git describe --tags --always --first-parent --match 'v*' 2>/dev/null)
+  # Shorten only the full describe hash; preserve the tag, distance, and any dirty suffix.
+  full_describe=$(git describe --tags --always --first-parent --match 'v*' --abbrev=40 2>/dev/null |
+    sed -E 's/(-[0-9]+-g[0-9a-f]{9})[0-9a-f]+(-dirty)?$/\1\2/; s/^([0-9a-f]{9})[0-9a-f]+(-dirty)?$/\1\2/')
   base_commit=$(git rev-parse "$nearest_tag"^{commit})
   best_tag=$(git -c "versionsort.suffix=-rc" tag --points-at "$base_commit" --sort version:refname -l 'v*' | tail -n 1)
   if [[ -n "$best_tag" ]]; then

--- a/hack/publish_containers.sh
+++ b/hack/publish_containers.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-set -x -e
+set -x -e -o pipefail
 
 CONTAINER_IMAGES="flightctl-api flightctl-pam-issuer flightctl-worker flightctl-periodic flightctl-alert-exporter cli-artifacts"
 
 
-GIT_REF=$(git rev-parse --short HEAD)
+GIT_REF=$(git rev-parse HEAD | cut -c1-9)
 
 for image in $CONTAINER_IMAGES; do
     podman tag ${image}:latest quay.io/flightctl/${image}:latest

--- a/packaging/rpm/flightctl.spec
+++ b/packaging/rpm/flightctl.spec
@@ -289,14 +289,14 @@ fi
     )" \
     SOURCE_GIT_TREE_STATE="clean" \
     SOURCE_GIT_COMMIT="$(
-        commit=$(git rev-parse --short HEAD 2>/dev/null || true);
+        commit=$( (git rev-parse HEAD 2>/dev/null || true) | cut -c1-9);
         if [ -z "$commit" ]; then
             commit=$(grep -v '^\$Format' packaging/rpm/git-metadata 2>/dev/null | tr -d '[:space:]');
         fi;
         if [ -z "$commit" ]; then
             commit=$(echo %{version} | grep -o '[-~]g[0-9a-f]*' | sed 's/[-~]g//');
         fi;
-        echo "${commit:-unknown}";
+        echo "${commit:-unknown}" | cut -c1-9;
     )" \
     %{?disable_fips} %make_build build-cli build-agent build-backup build-restore build-standalone build-mirror-images
 

--- a/packaging/rpm/git-metadata
+++ b/packaging/rpm/git-metadata
@@ -1,1 +1,1 @@
-$Format:%h$
+$Format:%H$

--- a/test/scripts/agent-images/scripts/build.sh
+++ b/test/scripts/agent-images/scripts/build.sh
@@ -25,7 +25,7 @@ current_tree_state() {
 
 SOURCE_GIT_TAG="${SOURCE_GIT_TAG:-$(${ROOT_DIR}/hack/current-version)}"
 SOURCE_GIT_TREE_STATE="${SOURCE_GIT_TREE_STATE:-$(current_tree_state)}"
-SOURCE_GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(cd "${ROOT_DIR}" && git rev-parse --short "HEAD^{commit}" 2>/dev/null || echo "unknown")}"
+SOURCE_GIT_COMMIT="${SOURCE_GIT_COMMIT:-$( (cd "${ROOT_DIR}" && git rev-parse "HEAD^{commit}" 2>/dev/null || echo "unknown") | cut -c1-9)}"
 TAG="${TAG:-$SOURCE_GIT_TAG}"
 
 PODMAN_LOG_LEVEL="${PODMAN_LOG_LEVEL:-info}"


### PR DESCRIPTION
Fix inconsistent Git hash lengths in build metadata by using exactly nine characters for standalone commit IDs, generated version suffixes, and RPM source-archive commit IDs.
- Replace git rev-parse --short calls with full-hash output followed by cut -c1-9.
- Shorten only the hash field in hack/current-version, preserving tags and commit distance.
- Store full hashes in RPM archive metadata and truncate the final RPM commit value after fallback resolution.
- Preserve existing error handling without adding helper scripts, a Go tool, or Python tests.

## Target release

release-1.4

