### PR TITLE
EDM-4844: Device status and enrollment behavioral fixes

### DIFF
--- a/internal/service/device/status.go
+++ b/internal/service/device/status.go
@@ -189,9 +189,46 @@ func updateServerSideDeviceUpdatedStatus(device *domain.Device, ctx context.Cont
 		device.Status.Updated.Info = lo.ToPtr("Device was updated to the latest device spec.")
 	}
 
+	overrideUpToDateForOsTarget(device)
+
 	return device.Status.Updated.Status != lastUpdateStatus
 }
 
+// overrideUpToDateForOsTarget downgrades an UpToDate device to OutOfDate when
+// the device has an OS target it cannot satisfy. Requires capabilities.osMode
+// to be reported; legacy devices without capabilities skip this check.
+func overrideUpToDateForOsTarget(device *domain.Device) {
+	if device.Status.Updated.Status != domain.DeviceUpdatedStatusUpToDate {
+		return
+	}
+	if device.Spec == nil || device.Spec.Os == nil {
+		return
+	}
+	if device.Status.Capabilities == nil || device.Status.Capabilities.OsMode == nil {
+		return
+	}
+
+	hasOsTarget := device.Spec.Os.Image != "" || device.Spec.Os.CatalogItemRef != nil
+	if !hasOsTarget {
+		return
+	}
+
+	if device.Spec.Os.Image != "" && device.Status.Os.Image != device.Spec.Os.Image {
+		device.Status.Updated.Status = domain.DeviceUpdatedStatusOutOfDate
+		device.Status.Updated.Info = lo.ToPtr(fmt.Sprintf("Device OS image mismatch: running %q, expected %q.", device.Status.Os.Image, device.Spec.Os.Image))
+	} else if *device.Status.Capabilities.OsMode == domain.OsModePackage &&
+		device.Spec.Os.CatalogItemRef != nil && device.Spec.Os.Image == "" {
+		device.Status.Updated.Status = domain.DeviceUpdatedStatusOutOfDate
+		device.Status.Updated.Info = lo.ToPtr("Device has a catalog OS target that cannot be satisfied.")
+	}
+}
+
+// managedDeviceOutOfDateMessage builds a human-readable info message for a
+// managed device whose spec is out of sync with its fleet. Priority order
+// matches internal/service/common/device.go:
+//  1. LastRolloutError annotation (highest)
+//  2. UpdateStateError condition message
+//  3. Generic fallback text
 func managedDeviceOutOfDateMessage(device *domain.Device) string {
 	baseMessage := "Device could not be updated to the fleet's latest device spec"
 	if device.Metadata.Annotations != nil {
@@ -208,18 +245,17 @@ func managedDeviceOutOfDateMessage(device *domain.Device) string {
 }
 
 // unmanagedDeviceOutOfDateMessage builds a human-readable info message for an
-// unmanaged device whose spec is not up-to-date.
+// unmanaged device whose spec is not up-to-date. Unmanaged devices do not have
+// rollout-error annotations, so only the update condition is checked.
 func unmanagedDeviceOutOfDateMessage(device *domain.Device) string {
 	baseMessage := domain.DeviceOutOfDateText
 
-	// Prefer update condition error if available
 	if updateCondition := domain.FindStatusCondition(device.Status.Conditions, domain.ConditionTypeDeviceUpdating); updateCondition != nil {
 		if updateCondition.Reason == string(domain.UpdateStateError) && updateCondition.Message != "" {
 			return fmt.Sprintf("%s: %s", baseMessage, updateCondition.Message)
 		}
 	}
 
-	// Final fallback to base message (skip rollout error check since unmanaged devices don't have rollout errors)
 	return baseMessage + "."
 }
 

--- a/internal/service/device/status_test.go
+++ b/internal/service/device/status_test.go
@@ -1,12 +1,15 @@
 package device
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/flightctl/flightctl/internal/domain"
 	"github.com/flightctl/flightctl/internal/service/common"
+	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -205,6 +208,230 @@ func TestUpdateServerSideApplicationStatus_PreservesDeviceStatus(t *testing.T) {
 				assert.NotNil(t, device.Status.ApplicationsSummary.Info)
 				assert.Equal(t, tt.expectedInfo, *device.Status.ApplicationsSummary.Info, "Info should be preserved from device")
 			}
+		})
+	}
+}
+
+func TestUpdateServerSideDeviceUpdatedStatus_OsImageMismatch(t *testing.T) {
+	ctx := context.Background()
+	orgId := uuid.New()
+	log := logrus.NewEntry(logrus.StandardLogger())
+
+	tests := []struct {
+		name               string
+		specOsImage        string
+		specCatalogItemRef *domain.CatalogItemRefSpec
+		statusOsImage      string
+		capabilities       *domain.DeviceCapabilities
+		expectedStatus     domain.DeviceUpdatedStatusType
+		expectInfoContains string
+	}{
+		{
+			name:           "When image-mode device has matching OS images it should remain UpToDate",
+			specOsImage:    "quay.io/flightctl/device:v7",
+			statusOsImage:  "quay.io/flightctl/device:v7",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:               "When image-mode device has mismatching OS images it should override to OutOfDate",
+			specOsImage:        "quay.io/flightctl/device:v7",
+			statusOsImage:      "quay.io/flightctl/device:base",
+			capabilities:       &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
+			expectedStatus:     domain.DeviceUpdatedStatusOutOfDate,
+			expectInfoContains: "OS image mismatch",
+		},
+		{
+			name:               "When package-mode device has spec OS image it should override to OutOfDate",
+			specOsImage:        "quay.io/flightctl/device:v7",
+			statusOsImage:      "",
+			capabilities:       &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			expectedStatus:     domain.DeviceUpdatedStatusOutOfDate,
+			expectInfoContains: "OS image mismatch",
+		},
+		{
+			name:           "When package-mode device has no spec OS image it should remain UpToDate",
+			specOsImage:    "",
+			statusOsImage:  "",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When legacy device without capabilities has empty status OS image it should remain UpToDate",
+			specOsImage:    "quay.io/flightctl/device:v7",
+			statusOsImage:  "",
+			capabilities:   nil,
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When legacy device without capabilities has mismatching OS images it should remain UpToDate",
+			specOsImage:    "quay.io/flightctl/device:v7",
+			statusOsImage:  "quay.io/flightctl/device:base",
+			capabilities:   nil,
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When device has capabilities with nil osMode it should remain UpToDate",
+			specOsImage:    "quay.io/flightctl/device:v7",
+			statusOsImage:  "quay.io/flightctl/device:base",
+			capabilities:   &domain.DeviceCapabilities{OsMode: nil},
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When no spec OS image is set it should remain UpToDate regardless of capabilities",
+			specOsImage:    "",
+			statusOsImage:  "quay.io/flightctl/device:base",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:               "When package-mode device has catalogItemRef only it should override to OutOfDate",
+			specCatalogItemRef: &domain.CatalogItemRefSpec{Catalog: "cat", Item: "os", Version: "v1"},
+			capabilities:       &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			expectedStatus:     domain.DeviceUpdatedStatusOutOfDate,
+			expectInfoContains: "catalog OS target",
+		},
+		{
+			name:               "When image-mode device has catalogItemRef only it should remain UpToDate",
+			specCatalogItemRef: &domain.CatalogItemRefSpec{Catalog: "cat", Item: "os", Version: "v1"},
+			capabilities:       &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModeImage)},
+			expectedStatus:     domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:               "When legacy device without capabilities has catalogItemRef it should remain UpToDate",
+			specCatalogItemRef: &domain.CatalogItemRefSpec{Catalog: "cat", Item: "os", Version: "v1"},
+			capabilities:       nil,
+			expectedStatus:     domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:               "When device has capabilities with nil osMode and catalogItemRef it should remain UpToDate",
+			specCatalogItemRef: &domain.CatalogItemRefSpec{Catalog: "cat", Item: "os", Version: "v1"},
+			capabilities:       &domain.DeviceCapabilities{OsMode: nil},
+			expectedStatus:     domain.DeviceUpdatedStatusUpToDate,
+		},
+		{
+			name:           "When package-mode device has no OS target it should remain UpToDate",
+			capabilities:   &domain.DeviceCapabilities{OsMode: lo.ToPtr(domain.OsModePackage)},
+			expectedStatus: domain.DeviceUpdatedStatusUpToDate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{
+				domain.DeviceAnnotationRenderedVersion: "4",
+			}
+			device := &domain.Device{
+				Metadata: domain.ObjectMeta{
+					Name:        lo.ToPtr("test-device"),
+					Annotations: &annotations,
+				},
+				Spec: &domain.DeviceSpec{},
+				Status: &domain.DeviceStatus{
+					LastSeen: lo.ToPtr(time.Now()),
+					Updated: domain.DeviceUpdatedStatus{
+						Status: domain.DeviceUpdatedStatusUpToDate,
+					},
+					Config: domain.DeviceConfigStatus{
+						RenderedVersion: "4",
+					},
+					Os: domain.DeviceOsStatus{
+						Image: tt.statusOsImage,
+					},
+					Capabilities: tt.capabilities,
+				},
+			}
+			if tt.specOsImage != "" {
+				device.Spec.Os = &domain.DeviceOsSpec{Image: tt.specOsImage}
+			}
+			if tt.specCatalogItemRef != nil {
+				if device.Spec.Os == nil {
+					device.Spec.Os = &domain.DeviceOsSpec{}
+				}
+				device.Spec.Os.CatalogItemRef = tt.specCatalogItemRef
+			}
+
+			updateServerSideDeviceUpdatedStatus(device, ctx, nil, log, orgId)
+
+			assert.Equal(t, tt.expectedStatus, device.Status.Updated.Status)
+			if tt.expectInfoContains != "" {
+				assert.Contains(t, *device.Status.Updated.Info, tt.expectInfoContains)
+			}
+		})
+	}
+}
+
+func TestManagedDeviceOutOfDateMessage_AnnotationPriority(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		conditions     []domain.Condition
+		expectContains string
+	}{
+		{
+			name: "When both annotation and error condition exist annotation should win",
+			annotations: map[string]string{
+				domain.DeviceAnnotationLastRolloutError: "annotation error",
+			},
+			conditions: []domain.Condition{
+				{
+					Type:    domain.ConditionTypeDeviceUpdating,
+					Status:  domain.ConditionStatusFalse,
+					Reason:  string(domain.UpdateStateError),
+					Message: "condition error",
+				},
+			},
+			expectContains: "annotation error",
+		},
+		{
+			name: "When non-error condition exists alongside annotation annotation should still win",
+			annotations: map[string]string{
+				domain.DeviceAnnotationLastRolloutError: "rollout failed",
+			},
+			conditions: []domain.Condition{
+				{
+					Type:    domain.ConditionTypeDeviceUpdating,
+					Status:  domain.ConditionStatusTrue,
+					Reason:  "InProgress",
+					Message: "applying spec",
+				},
+			},
+			expectContains: "rollout failed",
+		},
+		{
+			name: "When only error condition exists condition message should be used",
+			conditions: []domain.Condition{
+				{
+					Type:    domain.ConditionTypeDeviceUpdating,
+					Status:  domain.ConditionStatusFalse,
+					Reason:  string(domain.UpdateStateError),
+					Message: "condition error",
+				},
+			},
+			expectContains: "condition error",
+		},
+		{
+			name:           "When neither annotation nor error condition exists fallback text should be used",
+			expectContains: domain.DeviceOutOfSyncWithFleetText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			device := &domain.Device{
+				Metadata: domain.ObjectMeta{
+					Name: lo.ToPtr("test-device"),
+				},
+				Status: &domain.DeviceStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			if tt.annotations != nil {
+				device.Metadata.Annotations = &tt.annotations
+			}
+
+			msg := managedDeviceOutOfDateMessage(device)
+			assert.Contains(t, msg, tt.expectContains)
 		})
 	}
 }

--- a/internal/service/enrollmentconfig/handler.go
+++ b/internal/service/enrollmentconfig/handler.go
@@ -32,6 +32,12 @@ func (h *ServiceHandler) GetEnrollmentConfig(ctx context.Context, orgId uuid.UUI
 		return nil, domain.StatusInternalServerError("failed to get CA certificate")
 	}
 
+	// GetCABundle may read from a file (os.ReadFile), which is not context-aware.
+	// Check context cancellation before proceeding to the CSR lookup.
+	if err := ctx.Err(); err != nil {
+		return nil, domain.StatusInternalServerError("request cancelled")
+	}
+
 	clientCert := []byte{}
 	if params.Csr != nil {
 		if errs := validation.ValidateResourceName(params.Csr); len(errs) > 0 {


### PR DESCRIPTION
Jira: EDM-4844

Behavioral changes split out of #3406 for isolated review:

- `status.go` — extract `overrideUpToDateForOsTarget` and fix `managedDeviceOutOfDateMessage` priority (annotation → condition → fallback)
- `status_test.go` — catalog OS target and error-message priority tests
- `enrollmentconfig/handler.go` — `ctx.Err()` check after CA bundle retrieval

Depends on #3406 (refactor-only).

## Release target (required before merge to `main`)

- [x] **`release-1.3`**

---

**Stack:** 9/13 in the EDM-4806 closeout stack (based on `main`; stacks on #3406).