### PR TITLE
EDM-5718: flightctl-cleanup Job logs Failed to watch errors during helm uninstall

### DIFF
--- a/deploy/helm/flightctl/templates/flightctl-cleanup-job.yaml
+++ b/deploy/helm/flightctl/templates/flightctl-cleanup-job.yaml
@@ -73,11 +73,11 @@ metadata:
   labels:
     {{- include "flightctl.standardLabels" $ | nindent 4 }}
 rules:
-  - verbs: [get, list, delete]
+  - verbs: [get, list, delete, watch]
     apiGroups: ['']
     resources:
       - persistentvolumeclaims
-  - verbs: [get, list, delete]
+  - verbs: [get, list, delete, watch]
     apiGroups: ['batch']
     resources:
       - jobs


### PR DESCRIPTION
During helm uninstall, the cleanup Job's oc delete commands log Failed to watch errors because the cleanup Role only grants [get, list, delete] on PVCs and Jobs, but oc also tries to watch to confirm deletion
- Add watch to both verb lists in the cleanup Role , only affects the flightctl-cleanup ServiceAccount used by the post-delete hook

# Release target (required before merge to `main`)

- [x] **`release-1.4`** 