### PR TITLE
NO-ISSUE: Update vm-to-quadlet to 70ac48b (perf: JSON roundtrip, remo…

### DIFF
--- a/packaging/images/el10/Containerfile.worker
+++ b/packaging/images/el10/Containerfile.worker
@@ -3,7 +3,7 @@
 # pins k8s.io at a different version than flightctl.
 FROM registry.access.redhat.com/ubi10/go-toolset:1.26.7-1787775323 as vm-to-quadlet-build
 USER 0
-ARG VM_TO_QUADLET_COMMIT=5a693e470b5bf394abf55f768132d94f9a9d83c0
+ARG VM_TO_QUADLET_COMMIT=eb9f6cefda9f87f4517f258759477a315b3fa253
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/flightctl/vm-to-quadlet /src && \

--- a/packaging/images/el9/Containerfile.worker
+++ b/packaging/images/el9/Containerfile.worker
@@ -3,7 +3,7 @@
 # pins k8s.io at a different version than flightctl.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 as vm-to-quadlet-build
 USER 0
-ARG VM_TO_QUADLET_COMMIT=5a693e470b5bf394abf55f768132d94f9a9d83c0
+ARG VM_TO_QUADLET_COMMIT=eb9f6cefda9f87f4517f258759477a315b3fa253
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/root/go/pkg/mod \
     git clone https://github.com/flightctl/vm-to-quadlet /src && \

--- a/test/integration/tasks/vmrender/Containerfile.vm-to-quadlet
+++ b/test/integration/tasks/vmrender/Containerfile.vm-to-quadlet
@@ -1,7 +1,7 @@
 # Build stage: compile vm-to-quadlet at a pinned commit.
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1787774815 AS build
 USER 0
-ARG VM_TO_QUADLET_COMMIT=5a693e470b5bf394abf55f768132d94f9a9d83c0
+ARG VM_TO_QUADLET_COMMIT=eb9f6cefda9f87f4517f258759477a315b3fa253
 RUN git clone https://github.com/flightctl/vm-to-quadlet /src && \
     cd /src && git checkout ${VM_TO_QUADLET_COMMIT} && \
     CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -trimpath -ldflags="-s -w" -o /out/vm-to-quadlet ./cmd/vm-to-quadlet


### PR DESCRIPTION
…ve DeepCopy, buffer pool)

# Release target (required before merge to `main`)

Add at least one **`release-X.Y`** label to indicate which release(s) this change targets:

- [ ] **`release-X.Y`** — e.g., `release-1.2`, `release-1.3`

Multiple labels are allowed if the change targets more than one release. Labels can be added before the release branch exists.
