### PR TITLE
NO-ISSUE: deduplicate organizations reported by auth providers, Fixes #3534

### DIFF
--- a/internal/auth/authn/organization_extractor.go
+++ b/internal/auth/authn/organization_extractor.go
@@ -89,12 +89,22 @@ func (e *OrganizationExtractor) extractDynamicOrganizations(assignment *api.Auth
 		return organizations
 	}
 
+	// Identity providers commonly derive the organization claim from a multi-valued
+	// source (e.g. Entra ID app roles named "<org>.<role>"), which yields one entry per
+	// source value and therefore repeats an organization for every role the user holds
+	// in it. Organization membership is a set, so collapse duplicates while preserving
+	// first-seen order. Matches the PAM provider's extractOrganizations.
+	seen := make(map[string]struct{}, len(orgArray))
 	for _, item := range orgArray {
 		orgStr, ok := item.(string)
 		if !ok || orgStr == "" {
 			continue
 		}
 		orgName := e.applyPrefixSuffix(orgStr, dynamicAssignment.OrganizationNamePrefix, dynamicAssignment.OrganizationNameSuffix)
+		if _, duplicate := seen[orgName]; duplicate {
+			continue
+		}
+		seen[orgName] = struct{}{}
 		organizations = append(organizations, orgName)
 	}
 

--- a/internal/auth/authn/organization_extractor_test.go
+++ b/internal/auth/authn/organization_extractor_test.go
@@ -3,8 +3,11 @@ package authn
 import (
 	"testing"
 
+	api "github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/flightctl/flightctl/internal/auth/common"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApplyOrgPrefix(t *testing.T) {
@@ -24,6 +27,48 @@ func TestApplyOrgPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ApplyOrgPrefix(tt.orgName, tt.prefix)
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestExtractOrganizationsDynamic(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   map[string]interface{}
+		prefix   *string
+		suffix   *string
+		expected []string
+	}{
+		{
+			name:     "When the org claim repeats a value it should be reported once",
+			claims:   map[string]interface{}{"orginfo": []interface{}{"cz", "cz", "sk"}},
+			expected: []string{"cz", "sk"},
+		},
+		{
+			name:     "When duplicates are collapsed it should preserve first-seen order",
+			claims:   map[string]interface{}{"orginfo": []interface{}{"sk", "cz", "sk"}},
+			expected: []string{"sk", "cz"},
+		},
+		{
+			name:     "When a prefix and suffix are configured duplicates should still collapse",
+			claims:   map[string]interface{}{"orginfo": []interface{}{"cz", "cz"}},
+			prefix:   lo.ToPtr("tsp-"),
+			suffix:   lo.ToPtr("-org"),
+			expected: []string{"tsp-cz-org"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var assignment api.AuthOrganizationAssignment
+			require.NoError(t, assignment.FromAuthDynamicOrganizationAssignment(api.AuthDynamicOrganizationAssignment{
+				Type:                   api.AuthDynamicOrganizationAssignmentTypeDynamic,
+				ClaimPath:              []string{"orginfo"},
+				OrganizationNamePrefix: tt.prefix,
+				OrganizationNameSuffix: tt.suffix,
+			}))
+
+			extractor := NewOrganizationExtractor(&common.AuthOrganizationsConfig{OrganizationAssignment: &assignment})
+			assert.Equal(t, tt.expected, extractor.ExtractOrganizations(tt.claims, "user@example.com"))
 		})
 	}
 }

--- a/internal/auth/common/common.go
+++ b/internal/auth/common/common.go
@@ -252,6 +252,7 @@ func ShouldValidateOrg(method, path string) bool {
 // - Filtering out flightctl-admin from both global and org-specific roles (it's only used for super admin flag)
 // - Distributing remaining global roles to all organizations
 // - Combining org-specific and global roles for each organization
+// - Collapsing repeated organization entries so each organization is reported once
 func BuildReportedOrganizations(organizations []string, orgRoles map[string][]string, isInternalID bool) ([]ReportedOrganization, bool) {
 	reportedOrganizations := make([]ReportedOrganization, 0, len(organizations))
 	globalRoles := orgRoles["*"] // Get global roles if any
@@ -269,7 +270,19 @@ func BuildReportedOrganizations(organizations []string, orgRoles map[string][]st
 	}
 
 	// Build reported organizations with roles
+	seenOrgs := make(map[string]struct{}, len(organizations))
 	for _, org := range organizations {
+		// Callers may report the same organization more than once (e.g. an org claim
+		// derived from a multi-valued role claim). Exactly one ReportedOrganization per
+		// organization is the invariant downstream relies on: the identity mapper
+		// resolves each entry to the same DB row and appends it, so duplicates surface
+		// in GET /organizations. Collapsing is lossless because roles are looked up
+		// from orgRoles by name and are therefore identical for repeated entries.
+		if _, duplicate := seenOrgs[org]; duplicate {
+			continue
+		}
+		seenOrgs[org] = struct{}{}
+
 		// Use a map to deduplicate roles from the start
 		roleSet := make(map[string]struct{}, len(orgRoles[org])+len(filteredGlobalRolesMap))
 

--- a/internal/auth/common/common_test.go
+++ b/internal/auth/common/common_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/flightctl/flightctl/api/core/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildReportedOrganizations(t *testing.T) {
+	tests := []struct {
+		name          string
+		organizations []string
+		orgRoles      map[string][]string
+		expectedOrgs  []string
+		expectedRoles map[string][]string
+	}{
+		{
+			name:          "When an organization is reported twice it should appear once with its roles",
+			organizations: []string{"cz", "cz", "sk"},
+			orgRoles: map[string][]string{
+				"cz": {v1beta1.ExternalRoleInstaller, v1beta1.ExternalRoleOperator},
+				"sk": {v1beta1.ExternalRoleViewer},
+			},
+			expectedOrgs: []string{"cz", "sk"},
+			expectedRoles: map[string][]string{
+				"cz": {v1beta1.ExternalRoleInstaller, v1beta1.ExternalRoleOperator},
+				"sk": {v1beta1.ExternalRoleViewer},
+			},
+		},
+		{
+			name:          "When duplicates are collapsed it should preserve first-seen order",
+			organizations: []string{"sk", "cz", "sk"},
+			orgRoles: map[string][]string{
+				"cz": {v1beta1.ExternalRoleOperator},
+				"sk": {v1beta1.ExternalRoleViewer},
+			},
+			expectedOrgs: []string{"sk", "cz"},
+			expectedRoles: map[string][]string{
+				"cz": {v1beta1.ExternalRoleOperator},
+				"sk": {v1beta1.ExternalRoleViewer},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := BuildReportedOrganizations(tt.organizations, tt.orgRoles, false)
+
+			names := make([]string, 0, len(got))
+			for _, org := range got {
+				names = append(names, org.Name)
+				assert.Equal(t, tt.expectedRoles[org.Name], org.Roles, "roles for organization %q", org.Name)
+			}
+			assert.Equal(t, tt.expectedOrgs, names)
+		})
+	}
+}


### PR DESCRIPTION
… #3534

# Release target (required before merge to `main`)

- [ ] **`release-1.4`**

## Problem

Fixes #3534.

With `organizationAssignment.type: dynamic`, identity providers commonly derive the organization claim from a multi-valued source. Entra ID app roles named `<org>.<role>` — the natural pairing with `roleAssignment.separator: "."` — are extracted into the organization claim, producing one entry per role:

```json
{
  "orginfo": ["cz", "cz", "sk"],
  "roles": ["cz.flightctl-installer", "cz.flightctl-operator", "sk.flightctl-viewer"]
}
```

`GET /api/v1/organizations` then lists `cz` twice and the organization picker shows a duplicate entry. A user only has to hold two roles in one organization to hit it.

No deduplication happens along the path:

| Step | Location | Behavior |
|---|---|---|
| Read org claim | `internal/auth/authn/organization_extractor.go` | appends every array entry |
| Build reported orgs | `internal/auth/common/common.go`, `BuildReportedOrganizations` | deduplicates roles, not organizations |
| Map to DB | `internal/service/identity_mapper.go` | both entries resolve to the same row and both are appended |

The PAM provider already treats this list as a set (`extractOrganizations` in `internal/auth/oidc/pam/provider.go`), so the OIDC/OAuth2 path is inconsistent with an invariant the codebase already documents.

## Scope of impact

Cosmetic but user-visible. Not a correctness or security issue:

- the database stays correct — `UpsertMany` uses `OnConflict{Columns: external_id, DoNothing}`
- authorization is unaffected — `MappedIdentity.OrgRoles` is keyed by organization ID and its roles are already deduplicated

## Change

- deduplicate in `extractDynamicOrganizations`, where the claim array is read (root cause; OIDC and OAuth2)
- enforce one `ReportedOrganization` per organization in `BuildReportedOrganizations`, the shared entry point for the OIDC, OAuth2, AAP, OpenShift and K8s providers

Both preserve first-seen order. Collapsing is lossless: roles are looked up from `orgRoles` by organization name, so repeated entries produce identical `ReportedOrganization` values.

`IdentityMapper` is deliberately left unchanged — once its input is a set, it resolves each organization exactly once. Happy to extend it there instead, or in addition, if you prefer defence in depth at that layer.

## Testing

New table-driven cases covering the new behavior:

- `TestExtractOrganizationsDynamic` — repeated value reported once; first-seen order preserved; duplicates collapse after prefix/suffix is applied
- `TestBuildReportedOrganizations` — organization reported twice appears once with its roles; first-seen order preserved (new test file; the package had none)

Verified locally on darwin/arm64 with go1.27.1:

- `go test -race ./internal/auth/... ./internal/api_server/middleware/...` — pass
- `go test -race ./internal/... ./api/... ./pkg/...` — 129 packages pass. 9 fail identically on a clean tree with the change stashed: `internal/pam_issuer_server` (build failure on non-linux), `pkg/executer`, and `internal/agent/device/*`
- `golangci-lint run ./internal/auth/authn/... ./internal/auth/common/...` in the repo's lint image — 0 issues

## Follow-up, not in this PR

`AuthDynamicRoleAssignment.Validate` does not validate role names against `KnownExternalRoles`, while the static variant does. An unknown role name is accepted and then grants nothing, so a user logs in successfully and sees no resources. Worth a separate change if you agree.
