### PR TITLE
EDM-5889: ImageBuilder worker fails on Kubernetes when nested podman build cannot raise RLIMIT_NOFILE

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -432,6 +432,10 @@ CRI-O
  ImageContentSourcePolicy
  walkthrough
  arg
+ hardcoding
+ vendored
+ ulimits
+ ulimit
  - docs/user/references/cli-commands.md
 VNC
 stdin

--- a/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
+++ b/deploy/podman/flightctl-imagebuilder-worker/flightctl-imagebuilder-worker.container
@@ -39,10 +39,17 @@ Volume=flightctl-worker-storage:/var/lib/containers
 #   Volume=/etc/flightctl/service-images-auth.json:/root/.config/containers/auth.json:ro,z
 PodmanArgs=--privileged
 
+# Sets this container's own RLIMIT_NOFILE, which the imagebuilder-worker process then
+# forwards to the nested podman build container (see "File Descriptor Limits" in
+# configuring-imagebuilder.md). 1048576 matches what buildah expects when raising its
+# own nofile limit during builds.
+Ulimit=nofile=1048576:1048576
+
 [Service]
 Restart=always
 RestartSec=30
 Delegate=yes
+LimitNOFILE=1048576
 
 ExecStartPre=/usr/bin/flightctl-standalone render template --input-file /usr/share/flightctl/flightctl-imagebuilder-worker/config.yaml.template --output-file /etc/flightctl/flightctl-imagebuilder-worker/config.yaml
 

--- a/docs/user/installing/configuring-imagebuilder.md
+++ b/docs/user/installing/configuring-imagebuilder.md
@@ -770,9 +770,12 @@ setting "RLIMIT_NOFILE" limit to soft=1048576,hard=1048576
 1048576. This fails when the host's hard limit is lower (for example, 524288, which is the
 OpenShift default) and the container runtime does not grant `CAP_SYS_RESOURCE` to raise it.
 
-**Solution**: The ImageBuilder Worker sets `--ulimit nofile=1048576:1048576` on the nested
-podman worker container, relying on the privileged pod's `CAP_SYS_RESOURCE` capability.
-If you still encounter this error, the host itself must be configured to allow the higher limit.
+**Solution**: The ImageBuilder Worker reads its own current `RLIMIT_NOFILE` (soft and hard) at
+startup and passes it through to the nested podman worker container via
+`--ulimit nofile=<soft>:<hard>`, instead of hardcoding `1048576:1048576`. The nested container
+can therefore never end up with a higher limit than the worker process itself was granted, so
+raising the limit for builds is a matter of raising the **worker process's own**
+file-descriptor limit, as described below for each deployment type.
 
 On OpenShift, apply the following `MachineConfig` to the worker nodes:
 
@@ -803,13 +806,20 @@ processes on the node, including container runtimes.
 > `DefaultLimitNOFILE` is a system-wide default that applies to every service started by systemd
 > that does not have its own `LimitNOFILE=` directive in its unit file.
 
-On a Podman Quadlet (Linux host), use a systemd drop-in to raise the limit only for
-`flightctl-imagebuilder-worker.service`, without affecting any other service on the host:
+On a Podman Quadlet (Linux host), the shipped `flightctl-imagebuilder-worker.container` unit
+already requests `nofile=1048576:1048576` for itself (both `Ulimit=` under `[Container]` and
+`LimitNOFILE=` under `[Service]`), so no action is needed by default. If you need a different
+value — for example, to go higher than 1048576, or because your host's own limit is lower and
+podman fails to even start the worker container — override it with a drop-in rather than
+editing the vendored unit file (edits there are lost on upgrade):
 
 ```ini
-# /etc/systemd/system/flightctl-imagebuilder-worker.service.d/limits.conf
+# /etc/containers/systemd/flightctl-imagebuilder-worker.container.d/limits.conf
+[Container]
+Ulimit=nofile=<soft>:<hard>
+
 [Service]
-LimitNOFILE=1048576:1048576
+LimitNOFILE=<hard>
 ```
 
 Then reload and restart the service:
@@ -825,4 +835,17 @@ Verify the running service has the new limit:
 systemctl show flightctl-imagebuilder-worker.service | grep LimitNOFILE
 ```
 
-The output should show `LimitNOFILE=1048576` and `LimitNOFILESoft=1048576`.
+The output should show `LimitNOFILE=<hard>` and `LimitNOFILESoft=<soft>`.
+
+### File Descriptor Limits
+
+The ImageBuilder Worker never requests a higher `RLIMIT_NOFILE` for the nested build container
+than it was itself granted at startup, so raising the limit for builds means raising the
+**worker process's own** limit:
+
+- **Podman Quadlet**: set via `Ulimit=`/`LimitNOFILE=` in the `flightctl-imagebuilder-worker.container`
+  unit (`1048576:1048576` by default as of this release). Override with a drop-in as shown above.
+- **Kubernetes / OpenShift**: pod-level ulimits are not configurable through the Helm chart —
+  Kubernetes has no per-pod ulimit field. The limit comes entirely from the node/container
+  runtime defaults, and can only be raised at the node level, for example via the `MachineConfig`
+  shown above on OpenShift.

--- a/internal/imagebuilder_worker/tasks/imagebuild.go
+++ b/internal/imagebuilder_worker/tasks/imagebuild.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -720,6 +721,33 @@ func (w *podmanWorker) runInWorker(ctx context.Context, log logrus.FieldLogger, 
 	return nil
 }
 
+// nofileUlimitArgs returns the podman "--ulimit nofile=<cur>:<max>" arguments
+// derived from the current process' RLIMIT_NOFILE, so the worker container
+// inherits a limit Kubernetes will actually allow. It returns nil if the
+// current limit cannot be read.
+func nofileUlimitArgs(log logrus.FieldLogger) []string {
+	var rLimit unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rLimit); err != nil {
+		log.WithError(err).Warn("Could not read RLIMIT_NOFILE; worker container will use default ulimits")
+		return nil
+	}
+	arg := formatNofileUlimit(rLimit)
+	log.Debugf("Passing ulimit %s to worker container", arg)
+	return []string{"--ulimit", arg}
+}
+
+// formatNofileUlimit renders rLimit as a podman "--ulimit" value. A hard limit of
+// RLIM_INFINITY is common on bare-metal/quadlet hosts (unlike the typical Kubernetes case
+// where soft and hard are equal); it is capped to the soft limit rather than passed through
+// as a literal 0xffffffffffffffff.
+func formatNofileUlimit(rLimit unix.Rlimit) string {
+	max := rLimit.Max
+	if max == unix.RLIM_INFINITY {
+		max = rLimit.Cur
+	}
+	return fmt.Sprintf("nofile=%d:%d", rLimit.Cur, max)
+}
+
 // startPodmanWorker starts a detached podman worker container for building images.
 // It returns the container name, worker info, and a cleanup function.
 func (c *Consumer) startPodmanWorker(
@@ -819,6 +847,12 @@ ignore_chown_errors = "true"
 	if c.cfg.ImageBuilderWorker.EffectivePodmanSkipTLSVerify() {
 		startArgs = append(startArgs, "--tls-verify=false")
 	}
+
+	// Pass the current RLIMIT_NOFILE to the worker container so nested
+	// podman builds don't attempt to raise the limit beyond what Kubernetes
+	// permits for this pod, which would cause "operation not permitted".
+	startArgs = append(startArgs, nofileUlimitArgs(log)...)
+
 	startArgs = append(startArgs,
 		"--cap-add=SYS_ADMIN",
 		podmanImage,

--- a/internal/imagebuilder_worker/tasks/imagebuild_test.go
+++ b/internal/imagebuilder_worker/tasks/imagebuild_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 // mockRepositoryStore is a mock implementation of repositoryservice.Service for testing
@@ -435,6 +436,45 @@ func TestContainerfileTemplate_OnboardingARG(t *testing.T) {
 	require.Contains(t, containerfileTemplate, "flightctl-onboarding", "Template should reference flightctl-onboarding package")
 	require.Contains(t, containerfileTemplate, "flightctl-onboarding-setup.service", "Template should enable flightctl-onboarding-setup.service")
 	require.Contains(t, containerfileTemplate, "$PACKAGES", "Template should use $PACKAGES variable for install")
+}
+
+func TestNofileUlimitArgs_ReflectsCurrentRlimit(t *testing.T) {
+	var want unix.Rlimit
+	err := unix.Getrlimit(unix.RLIMIT_NOFILE, &want)
+	require.NoError(t, err)
+
+	args := nofileUlimitArgs(log.InitLogs())
+
+	require.Equal(t, []string{"--ulimit", formatNofileUlimit(want)}, args)
+}
+
+func TestFormatNofileUlimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit unix.Rlimit
+		want  string
+	}{
+		{
+			name:  "finite hard limit",
+			limit: unix.Rlimit{Cur: 1024, Max: 4096},
+			want:  "nofile=1024:4096",
+		},
+		{
+			name:  "soft equals hard (typical Kubernetes case)",
+			limit: unix.Rlimit{Cur: 1048576, Max: 1048576},
+			want:  "nofile=1048576:1048576",
+		},
+		{
+			name:  "infinite hard limit is capped to the soft limit",
+			limit: unix.Rlimit{Cur: 1024, Max: unix.RLIM_INFINITY},
+			want:  "nofile=1024:1024",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, formatNofileUlimit(tt.limit))
+		})
+	}
 }
 
 func TestInstallCACertInWorker_NilCaCrt(t *testing.T) {


### PR DESCRIPTION
Replaces #2722 (closed due to inactivity; that branch had diverged 992 commits from main and could not be rebased in place).

Passes the ImageBuilder Worker's own current `RLIMIT_NOFILE` (soft and hard) through to the nested podman worker container via `--ulimit`, instead of hardcoding `1048576:1048576`. This fixes builds failing on Kubernetes with `operation not permitted` when the pod's own hard limit is lower than what buildah expects.

Addresses review feedback from #2722:
- Use `golang.org/x/sys/unix` instead of the frozen `syscall` package
- Cap a hard limit of `RLIM_INFINITY` to the soft limit before passing it to podman
- Ship `Ulimit=`/`LimitNOFILE=` in the `flightctl-imagebuilder-worker.container` quadlet unit so Podman deployments keep getting `1048576` by default (previously hardcoded in Go, now sourced from the unit)
- Update `configuring-imagebuilder.md` to describe the new dynamic behavior and how to raise the limit on each deployment type
- `EDM-5889:` commit prefix

Also adds unit test coverage for the ulimit-argument construction, including the `RLIM_INFINITY` capping case.