### PR TITLE
EDM-5770: Align degraded VM application status

### DIFF
--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -366,7 +366,9 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 		newStatus = v1beta1.ApplicationStatusStarting
 		summary.Status = v1beta1.ApplicationsSummaryStatusDegraded
 	case isRunningDegraded(total, healthy, initializing):
-		newStatus = v1beta1.ApplicationStatusRunning
+		// A partially available application is still recovering. Report Starting
+		// so the individual status remains consistent with a Degraded summary.
+		newStatus = v1beta1.ApplicationStatusStarting
 		summary.Status = v1beta1.ApplicationsSummaryStatusDegraded
 	case isErrored(total, healthy, initializing):
 		newStatus = v1beta1.ApplicationStatusError

--- a/internal/agent/device/applications/applications.go
+++ b/internal/agent/device/applications/applications.go
@@ -361,7 +361,9 @@ func (a *application) Status() (*v1beta1.DeviceApplicationStatus, v1beta1.Device
 		newStatus = v1beta1.ApplicationStatusRunning
 		summary.Status = v1beta1.ApplicationsSummaryStatusHealthy
 	case isRunningUnhealthy(total, healthy, unhealthy, initializing, stopped+stopping):
-		newStatus = v1beta1.ApplicationStatusRunning
+		// A health-degraded application is still recovering. Report Starting so
+		// the individual status remains consistent with a Degraded summary.
+		newStatus = v1beta1.ApplicationStatusStarting
 		summary.Status = v1beta1.ApplicationsSummaryStatusDegraded
 	case isRunningDegraded(total, healthy, initializing):
 		newStatus = v1beta1.ApplicationStatusRunning

--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -225,7 +225,7 @@ func TestApplicationStatus(t *testing.T) {
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusHealthy,
 		},
 		{
-			name: "When single workload is unhealthy it should report Running degraded",
+			name: "When single workload is unhealthy it should report Starting degraded",
 			workloads: []Workload{
 				{
 					Name:   "container1",
@@ -233,11 +233,11 @@ func TestApplicationStatus(t *testing.T) {
 				},
 			},
 			expectedReady:         "0/1",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
-			name: "When one workload is unhealthy and one is healthy it should report Running degraded",
+			name: "When one workload is unhealthy and one is healthy it should report Starting degraded",
 			workloads: []Workload{
 				{
 					Name:   "container1",
@@ -249,11 +249,11 @@ func TestApplicationStatus(t *testing.T) {
 				},
 			},
 			expectedReady:         "1/2",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
-			name: "When all workloads are unhealthy it should report Running degraded",
+			name: "When all workloads are unhealthy it should report Starting degraded",
 			workloads: []Workload{
 				{
 					Name:   "container1",
@@ -265,11 +265,11 @@ func TestApplicationStatus(t *testing.T) {
 				},
 			},
 			expectedReady:         "0/2",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
-			name: "When one workload is unhealthy and one is exited it should report Running degraded",
+			name: "When one workload is unhealthy and one is exited it should report Starting degraded",
 			workloads: []Workload{
 				{
 					Name:   "container1",
@@ -281,11 +281,11 @@ func TestApplicationStatus(t *testing.T) {
 				},
 			},
 			expectedReady:         "0/2",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
-			name: "When one workload is unhealthy and one has died it should report Running degraded",
+			name: "When one workload is unhealthy and one has died it should report Starting degraded",
 			workloads: []Workload{
 				{
 					Name:   "container1",
@@ -297,17 +297,17 @@ func TestApplicationStatus(t *testing.T) {
 				},
 			},
 			expectedReady:         "0/2",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
-			name: "When one workload is unhealthy and one is stopping it should report Running degraded",
+			name: "When one workload is unhealthy and one is stopping it should report Starting degraded",
 			workloads: []Workload{
 				{Name: "container1", Status: StatusUnhealthy},
 				{Name: "container2", Status: StatusStop},
 			},
 			expectedReady:         "0/2",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
@@ -323,7 +323,7 @@ func TestApplicationStatus(t *testing.T) {
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusHealthy,
 		},
 		{
-			name: "When a running workload is unhealthy and init containers have exited it should report Running degraded",
+			name: "When a running workload is unhealthy and init containers have exited it should report Starting degraded",
 			workloads: []Workload{
 				{Name: "compute", Status: StatusUnhealthy},
 				{Name: "virt-launcher", Status: StatusRunning},
@@ -331,7 +331,7 @@ func TestApplicationStatus(t *testing.T) {
 				{Name: "init-config", Status: StatusExited},
 			},
 			expectedReady:         "1/4",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 	}

--- a/internal/agent/device/applications/applications_test.go
+++ b/internal/agent/device/applications/applications_test.go
@@ -112,7 +112,7 @@ func TestApplicationStatus(t *testing.T) {
 			expected:              v1beta1.AppTypeCompose,
 		},
 		{
-			name: "app running degraded",
+			name: "app starting degraded after workload died",
 			workloads: []Workload{
 				{
 					Name:   "container1",
@@ -124,12 +124,12 @@ func TestApplicationStatus(t *testing.T) {
 				},
 			},
 			expectedReady:         "1/2",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 			expected:              v1beta1.AppTypeCompose,
 		},
 		{
-			name: "app running degraded",
+			name: "app starting degraded after workload exited",
 			workloads: []Workload{
 				{
 					Name:   "container1",
@@ -141,7 +141,7 @@ func TestApplicationStatus(t *testing.T) {
 				},
 			},
 			expectedReady:         "1/2",
-			expectedStatus:        v1beta1.ApplicationStatusRunning,
+			expectedStatus:        v1beta1.ApplicationStatusStarting,
 			expectedSummaryStatus: v1beta1.ApplicationsSummaryStatusDegraded,
 			expected:              v1beta1.AppTypeCompose,
 		},

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -495,14 +495,14 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 		expectedSummary        v1beta1.ApplicationsSummaryStatusType
 	}{
 		{
-			name:                   "When running VM workload becomes unhealthy it should report Running degraded",
+			name:                   "When running VM workload becomes unhealthy it should report Starting degraded",
 			appType:                v1beta1.AppTypeVm,
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "unhealthy",
 			expectedWorkloadStatus: StatusUnhealthy,
 			expectedRequiresHealth: true,
 			expectedReady:          "0/1",
-			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedAppStatus:      v1beta1.ApplicationStatusStarting,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
@@ -517,14 +517,14 @@ func TestUpdateContainerHealthStatus(t *testing.T) {
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusHealthy,
 		},
 		{
-			name:                   "When VM health is starting it should report Running degraded",
+			name:                   "When VM health is starting it should report Starting degraded",
 			appType:                v1beta1.AppTypeVm,
 			initialWorkloadStatus:  StatusRunning,
 			health:                 "starting",
 			expectedWorkloadStatus: StatusUnhealthy,
 			expectedRequiresHealth: true,
 			expectedReady:          "0/1",
-			expectedAppStatus:      v1beta1.ApplicationStatusRunning,
+			expectedAppStatus:      v1beta1.ApplicationStatusStarting,
 			expectedSummary:        v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
@@ -699,7 +699,7 @@ func TestVMHealthGatedCrashLoopSequence(t *testing.T) {
 	require.True(ok)
 	require.True(workload.RequiresHealth)
 	require.Equal(StatusUnhealthy, workload.Status)
-	assertSummary("0/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusDegraded)
+	assertSummary("0/1", v1beta1.ApplicationStatusStarting, v1beta1.ApplicationsSummaryStatusDegraded)
 
 	died := mockPodmanEventError(appName, v1beta1.CurrentProcessUsername, service, "died", 2)
 	died.ID = "container-id-1"
@@ -715,12 +715,12 @@ func TestVMHealthGatedCrashLoopSequence(t *testing.T) {
 	require.True(workload.RequiresHealth)
 	require.Equal(StatusUnhealthy, workload.Status)
 	require.Equal("container-id-2", workload.ID)
-	assertSummary("0/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusDegraded)
+	assertSummary("0/1", v1beta1.ApplicationStatusStarting, v1beta1.ApplicationsSummaryStatusDegraded)
 
 	starting2 := mockPodmanHealthEvent(appName, v1beta1.CurrentProcessUsername, service, "starting")
 	starting2.ID = "container-id-2"
 	monitor.handleEvent(t.Context(), starting2)
-	assertSummary("0/1", v1beta1.ApplicationStatusRunning, v1beta1.ApplicationsSummaryStatusDegraded)
+	assertSummary("0/1", v1beta1.ApplicationStatusStarting, v1beta1.ApplicationsSummaryStatusDegraded)
 
 	healthy := mockPodmanHealthEvent(appName, v1beta1.CurrentProcessUsername, service, "healthy")
 	healthy.ID = "container-id-2"

--- a/internal/agent/device/applications/podman_monitor_test.go
+++ b/internal/agent/device/applications/podman_monitor_test.go
@@ -76,7 +76,7 @@ func TestListenForEvents(t *testing.T) {
 				mockPodmanEventSuccess("app1", v1beta1.CurrentProcessUsername, "app1-service-2", "stop"),
 			},
 			expectedReady:   "1/2",
-			expectedStatus:  v1beta1.ApplicationStatusRunning,
+			expectedStatus:  v1beta1.ApplicationStatusStarting,
 			expectedSummary: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
@@ -92,7 +92,7 @@ func TestListenForEvents(t *testing.T) {
 				mockPodmanEventError("app1", v1beta1.CurrentProcessUsername, "app1-service-2", "died", 137),
 			},
 			expectedReady:   "1/2",
-			expectedStatus:  v1beta1.ApplicationStatusRunning,
+			expectedStatus:  v1beta1.ApplicationStatusStarting,
 			expectedSummary: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{
@@ -121,7 +121,7 @@ func TestListenForEvents(t *testing.T) {
 				mockPodmanEventSuccess("app1", v1beta1.CurrentProcessUsername, "app1-service-2", "die"),
 			},
 			expectedReady:   "1/2",
-			expectedStatus:  v1beta1.ApplicationStatusRunning,
+			expectedStatus:  v1beta1.ApplicationStatusStarting,
 			expectedSummary: v1beta1.ApplicationsSummaryStatusDegraded,
 		},
 		{


### PR DESCRIPTION
## Summary

- Report health-degraded VM applications as `Starting` instead of `Running`.
- Keep the application summary as `Degraded`.
- Update VM health and crash-loop regression expectations.

This preserves the existing API enum and aligns individual application status with the documented `Degraded` summary contract.

## Validation

- `make lint` — passed
- `go test ./internal/agent/device/applications/...` — passed
- `go test -race ./internal/agent/device/applications/...` — passed
- `make unit-test RACE=0 COVERAGE=0` — 6,924 tests completed; 5 unrelated failures remain in `internal/agent/device/console` and `internal/agent/device/systeminfo`

Jira: EDM-5770