### PR TITLE
EDM-5264: reject duplicate vm published host ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Flight Control is a service for declarative management of fleets of edge devices
 - **API changes:** Edit OpenAPI YAML and hand-maintained types (e.g. `api/core/v1beta1/types.go`), then `make generate`. Do not edit `*.gen.go` by hand.
 - **Documentation:** User docs under `docs/user/`, developer docs under `docs/developer/`. Run `make lint-docs` and `make spellcheck-docs` for user docs.
 - **Commits:** All commits must be signed (GPG or SSH). Commit messages must be prefixed with Jira issue key (e.g., `EDM-1234: Description`) or `NO-ISSUE:` for trivial changes.
+- **Jira references:** Do not include Jira issue keys or Jira URLs in source code, comments, test names, or user-facing documentation. Track work in commit messages, pull requests, and Jira instead.
 
 ## Before committing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Flight Control is a service for declarative management of fleets of edge devices
 - **Testing:** Use table-driven tests. Name test cases with "When ... it should ..." format for clarity.
 - **API changes:** Edit OpenAPI YAML and hand-maintained types (e.g. `api/core/v1beta1/types.go`), then `make generate`. Do not edit `*.gen.go` by hand.
 - **Documentation:** User docs under `docs/user/`, developer docs under `docs/developer/`. Run `make lint-docs` and `make spellcheck-docs` for user docs.
-- **Commits:** All commits must be signed (GPG or SSH). Commit messages must be prefixed with Jira issue key (e.g., `EDM-1234: Description`) or `NO-ISSUE:` for trivial changes.
+- **Commits:** All commits must be signed (GPG or SSH). Commit messages must be prefixed with Jira issue key (e.g., `<PROJECT>-<NUMBER>: Description`) or `NO-ISSUE:` for trivial changes.
 - **Jira references:** Do not include Jira issue keys or Jira URLs in source code, comments, test names, or user-facing documentation. Track work in commit messages, pull requests, and Jira instead.
 
 ## Before committing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ When working in a specific part of the codebase, follow the guidance in the corr
 ## Commits
 
 - **Signed commits** – All commits must be signed (e.g. with GPG or SSH). Configure signing in Git and sign each commit before pushing.
-- **Jira prefix in title** – The first line of the commit message (the title) must be prefixed with the relevant Jira issue key, e.g. `EDM-1234: Short description of the change`. Use `NO-ISSUE:` for trivial or non-ticket changes (e.g. typos, minor docs). See the git history for examples: `git log --oneline`.
+- **Jira prefix in title** – The first line of the commit message (the title) must be prefixed with the relevant Jira issue key, e.g. `<PROJECT>-<NUMBER>: Short description of the change`. Use `NO-ISSUE:` for trivial or non-ticket changes (e.g. typos, minor docs). See the git history for examples: `git log --oneline`.
 - **No Jira references in code** – Keep Jira issue keys and URLs out of source code, comments, tests, and documentation. Use commit messages, pull requests, and Jira for issue tracking.
 
 ## Submitting changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ When working in a specific part of the codebase, follow the guidance in the corr
 
 - **Signed commits** – All commits must be signed (e.g. with GPG or SSH). Configure signing in Git and sign each commit before pushing.
 - **Jira prefix in title** – The first line of the commit message (the title) must be prefixed with the relevant Jira issue key, e.g. `EDM-1234: Short description of the change`. Use `NO-ISSUE:` for trivial or non-ticket changes (e.g. typos, minor docs). See the git history for examples: `git log --oneline`.
+- **No Jira references in code** – Keep Jira issue keys and URLs out of source code, comments, tests, and documentation. Use commit messages, pull requests, and Jira for issue tracking.
 
 ## Submitting changes
 

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -1088,6 +1088,7 @@ func validateApplicationPortConflicts(app ApplicationProviderSpec, appName strin
 	return allErrs
 }
 
+// publishedPortKey normalizes a typed host-to-guest mapping for conflict checks.
 func publishedPortKey(port string) (string, bool) {
 	if !containerPortPattern.MatchString(port) {
 		return "", false
@@ -1098,6 +1099,10 @@ func publishedPortKey(port string) (string, bool) {
 	if err != nil || hostPort < privilegedPortRangeStart || hostPort > portRangeEnd {
 		return "", false
 	}
+	guestPort, err := strconv.Atoi(strings.SplitN(colonParts[1], "/", 2)[0])
+	if err != nil || guestPort < privilegedPortRangeStart || guestPort > portRangeEnd {
+		return "", false
+	}
 
 	protocol := "tcp"
 	if protocolParts := strings.SplitN(colonParts[1], "/", 2); len(protocolParts) == 2 {
@@ -1106,14 +1111,20 @@ func publishedPortKey(port string) (string, bool) {
 	return fmt.Sprintf("%d/%s", hostPort, protocol), true
 }
 
+// validateQuadletApplicationPortConflicts checks inline Quadlet container units
+// against the device-wide published-port set used by VM and container apps.
 func validateQuadletApplicationPortConflicts(app ApplicationProviderSpec, appName string, seenPorts map[string]string) []error {
 	quadletApp, err := app.AsQuadletApplication()
 	if err != nil || quadletApp.Type() != InlineApplicationProviderType {
+		// validateQuadletApplication reports malformed provider conversions; avoid
+		// duplicating that error while keeping conflict detection best effort.
 		return nil
 	}
 
 	inlineSpec, err := quadletApp.AsInlineApplicationProviderSpec()
 	if err != nil {
+		// The application validator reports this conversion error with its normal
+		// provider path; avoid emitting a second error here.
 		return nil
 	}
 
@@ -1125,14 +1136,20 @@ func validateQuadletApplicationPortConflicts(app ApplicationProviderSpec, appNam
 
 		content, err := decodeApplicationContent(inline)
 		if err != nil {
+			// ApplicationContent.Validate already reports decoding errors with the
+			// inline content path.
 			continue
 		}
 		unit, err := quadlet.NewUnit(content)
 		if err != nil {
+			// ValidateContents already reports Quadlet parse errors with the file
+			// path, so there is no additional conflict data to process.
 			continue
 		}
 		ports, err := unit.LookupAll(quadlet.ContainerGroup, quadlet.PublishPortKey)
 		if err != nil {
+			// Missing [Container]/PublishPort is valid for other Quadlet files and
+			// produces no published host port to track.
 			continue
 		}
 
@@ -1150,6 +1167,8 @@ func validateQuadletApplicationPortConflicts(app ApplicationProviderSpec, appNam
 	return allErrs
 }
 
+// quadletPublishedPortKeys returns normalized host-port/protocol keys for a
+// Quadlet PublishPort value, expanding an explicitly configured host range.
 func quadletPublishedPortKeys(port string) []string {
 	portParts := strings.SplitN(port, "/", 2)
 	protocol := "tcp"

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -999,8 +999,6 @@ func (c ApplicationContent) IsPlain() bool {
 func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []error {
 	allErrs := []error{}
 	seenAppNames := make(map[string]struct{})
-	// EDM-5264: published host ports are scoped to the device, not to an
-	// individual VM or container application.
 	seenPublishedPorts := make(map[string]string)
 
 	for _, app := range apps {
@@ -1034,6 +1032,7 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 			allErrs = append(allErrs, validateComposeApplication(app, appName, fleetTemplate)...)
 		case AppTypeQuadlet:
 			allErrs = append(allErrs, validateQuadletApplication(app, appName, fleetTemplate)...)
+			allErrs = append(allErrs, validateQuadletApplicationPortConflicts(app, appName, seenPublishedPorts)...)
 		case AppTypeVm:
 			allErrs = append(allErrs, validateVmApplication(app, appName, fleetTemplate)...)
 			allErrs = append(allErrs, validateApplicationPortConflicts(app, appName, AppTypeVm, seenPublishedPorts)...)
@@ -1105,6 +1104,85 @@ func publishedPortKey(port string) (string, bool) {
 		protocol = protocolParts[1]
 	}
 	return fmt.Sprintf("%d/%s", hostPort, protocol), true
+}
+
+func validateQuadletApplicationPortConflicts(app ApplicationProviderSpec, appName string, seenPorts map[string]string) []error {
+	quadletApp, err := app.AsQuadletApplication()
+	if err != nil || quadletApp.Type() != InlineApplicationProviderType {
+		return nil
+	}
+
+	inlineSpec, err := quadletApp.AsInlineApplicationProviderSpec()
+	if err != nil {
+		return nil
+	}
+
+	var allErrs []error
+	for _, inline := range inlineSpec.Inline {
+		if inline.Content == nil || !strings.HasSuffix(inline.Path, quadlet.ContainerExtension) {
+			continue
+		}
+
+		content, err := decodeApplicationContent(inline)
+		if err != nil {
+			continue
+		}
+		unit, err := quadlet.NewUnit(content)
+		if err != nil {
+			continue
+		}
+		ports, err := unit.LookupAll(quadlet.ContainerGroup, quadlet.PublishPortKey)
+		if err != nil {
+			continue
+		}
+
+		pathPrefix := fmt.Sprintf("spec.applications[%s].inline[%s].content", appName, inline.Path)
+		for _, port := range ports {
+			for _, portKey := range quadletPublishedPortKeys(port) {
+				if previousApp, exists := seenPorts[portKey]; exists {
+					allErrs = append(allErrs, fmt.Errorf("%s: host port %s is already used by application %q", pathPrefix, portKey, previousApp))
+					continue
+				}
+				seenPorts[portKey] = appName
+			}
+		}
+	}
+	return allErrs
+}
+
+func quadletPublishedPortKeys(port string) []string {
+	portParts := strings.SplitN(port, "/", 2)
+	protocol := "tcp"
+	if len(portParts) == 2 {
+		protocol = portParts[1]
+	}
+	if protocol != "tcp" && protocol != "udp" && protocol != "sctp" {
+		return nil
+	}
+
+	colonParts := strings.Split(portParts[0], ":")
+	if len(colonParts) < 2 {
+		return nil
+	}
+	hostPortRange := colonParts[len(colonParts)-2]
+	rangeParts := strings.SplitN(hostPortRange, "-", 2)
+	start, err := strconv.Atoi(rangeParts[0])
+	if err != nil || start < privilegedPortRangeStart || start > portRangeEnd {
+		return nil
+	}
+	end := start
+	if len(rangeParts) == 2 {
+		end, err = strconv.Atoi(rangeParts[1])
+		if err != nil || end < start || end > portRangeEnd {
+			return nil
+		}
+	}
+
+	keys := make([]string, 0, end-start+1)
+	for hostPort := start; hostPort <= end; hostPort++ {
+		keys = append(keys, fmt.Sprintf("%d/%s", hostPort, protocol))
+	}
+	return keys
 }
 
 // validateApplicationLifecycleFieldsReadOnly rejects client-supplied values for

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -999,6 +999,9 @@ func (c ApplicationContent) IsPlain() bool {
 func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []error {
 	allErrs := []error{}
 	seenAppNames := make(map[string]struct{})
+	// EDM-5264: published VM host ports are scoped to the device, not to an
+	// individual application.
+	seenVmPublishedPorts := make(map[string]string)
 
 	for _, app := range apps {
 		appType, err := app.Discriminator()
@@ -1032,12 +1035,56 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 			allErrs = append(allErrs, validateQuadletApplication(app, appName, fleetTemplate)...)
 		case AppTypeVm:
 			allErrs = append(allErrs, validateVmApplication(app, appName, fleetTemplate)...)
+			allErrs = append(allErrs, validateVmApplicationPortConflicts(app, appName, seenVmPublishedPorts)...)
 		default:
 			allErrs = append(allErrs, fmt.Errorf("unknown application type: %s", appType))
 		}
 	}
 
 	return allErrs
+}
+
+func validateVmApplicationPortConflicts(app ApplicationProviderSpec, appName string, seenPorts map[string]string) []error {
+	vm, err := app.AsVmApplication()
+	if err != nil || vm.PublishPorts == nil {
+		return nil
+	}
+
+	pathPrefix := fmt.Sprintf("spec.applications[%s].publishPorts", appName)
+	var allErrs []error
+	for i, port := range *vm.PublishPorts {
+		portKey, ok := vmPublishedPortKey(port)
+		if !ok {
+			// The format and range validator reports the more useful error for
+			// malformed entries; they cannot participate in conflict detection.
+			continue
+		}
+
+		if previousApp, exists := seenPorts[portKey]; exists {
+			allErrs = append(allErrs, fmt.Errorf("%s[%d]: host port %s is already used by application %q", pathPrefix, i, portKey, previousApp))
+			continue
+		}
+		seenPorts[portKey] = appName
+	}
+	return allErrs
+}
+
+func vmPublishedPortKey(port string) (string, bool) {
+	if !containerPortPattern.MatchString(port) {
+		return "", false
+	}
+
+	colonParts := strings.SplitN(port, ":", 2)
+	hostPort, err := strconv.Atoi(colonParts[0])
+	if err != nil || hostPort < privilegedPortRangeStart || hostPort > portRangeEnd {
+		return "", false
+	}
+
+	protocol := "tcp"
+	if protocolParts := strings.SplitN(colonParts[1], "/", 2); len(protocolParts) == 2 {
+		protocol = protocolParts[1]
+	}
+	return fmt.Sprintf("%d/%s", hostPort, protocol), true
 }
 
 // validateApplicationLifecycleFieldsReadOnly rejects client-supplied values for

--- a/api/core/v1beta1/validation.go
+++ b/api/core/v1beta1/validation.go
@@ -999,9 +999,9 @@ func (c ApplicationContent) IsPlain() bool {
 func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []error {
 	allErrs := []error{}
 	seenAppNames := make(map[string]struct{})
-	// EDM-5264: published VM host ports are scoped to the device, not to an
-	// individual application.
-	seenVmPublishedPorts := make(map[string]string)
+	// EDM-5264: published host ports are scoped to the device, not to an
+	// individual VM or container application.
+	seenPublishedPorts := make(map[string]string)
 
 	for _, app := range apps {
 		appType, err := app.Discriminator()
@@ -1027,6 +1027,7 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 		switch AppType(appType) {
 		case AppTypeContainer:
 			allErrs = append(allErrs, validateContainerApplication(app, appName, fleetTemplate)...)
+			allErrs = append(allErrs, validateApplicationPortConflicts(app, appName, AppTypeContainer, seenPublishedPorts)...)
 		case AppTypeHelm:
 			allErrs = append(allErrs, ValidateHelmApplication(app, appName, fleetTemplate)...)
 		case AppTypeCompose:
@@ -1035,7 +1036,7 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 			allErrs = append(allErrs, validateQuadletApplication(app, appName, fleetTemplate)...)
 		case AppTypeVm:
 			allErrs = append(allErrs, validateVmApplication(app, appName, fleetTemplate)...)
-			allErrs = append(allErrs, validateVmApplicationPortConflicts(app, appName, seenVmPublishedPorts)...)
+			allErrs = append(allErrs, validateApplicationPortConflicts(app, appName, AppTypeVm, seenPublishedPorts)...)
 		default:
 			allErrs = append(allErrs, fmt.Errorf("unknown application type: %s", appType))
 		}
@@ -1044,16 +1045,35 @@ func validateApplications(apps []ApplicationProviderSpec, fleetTemplate bool) []
 	return allErrs
 }
 
-func validateVmApplicationPortConflicts(app ApplicationProviderSpec, appName string, seenPorts map[string]string) []error {
-	vm, err := app.AsVmApplication()
-	if err != nil || vm.PublishPorts == nil {
+func validateApplicationPortConflicts(app ApplicationProviderSpec, appName string, appType AppType, seenPorts map[string]string) []error {
+	var ports *[]ApplicationPort
+	var portsField string
+	switch appType {
+	case AppTypeContainer:
+		container, err := app.AsContainerApplication()
+		if err != nil {
+			return nil
+		}
+		ports = container.Ports
+		portsField = "ports"
+	case AppTypeVm:
+		vm, err := app.AsVmApplication()
+		if err != nil {
+			return nil
+		}
+		ports = vm.PublishPorts
+		portsField = "publishPorts"
+	default:
+		return nil
+	}
+	if ports == nil {
 		return nil
 	}
 
-	pathPrefix := fmt.Sprintf("spec.applications[%s].publishPorts", appName)
+	pathPrefix := fmt.Sprintf("spec.applications[%s].%s", appName, portsField)
 	var allErrs []error
-	for i, port := range *vm.PublishPorts {
-		portKey, ok := vmPublishedPortKey(port)
+	for i, port := range *ports {
+		portKey, ok := publishedPortKey(port)
 		if !ok {
 			// The format and range validator reports the more useful error for
 			// malformed entries; they cannot participate in conflict detection.
@@ -1069,7 +1089,7 @@ func validateVmApplicationPortConflicts(app ApplicationProviderSpec, appName str
 	return allErrs
 }
 
-func vmPublishedPortKey(port string) (string, bool) {
+func publishedPortKey(port string) (string, bool) {
 	if !containerPortPattern.MatchString(port) {
 		return "", false
 	}

--- a/api/core/v1beta1/validation_test.go
+++ b/api/core/v1beta1/validation_test.go
@@ -1134,6 +1134,14 @@ func TestValidateApplications(t *testing.T) {
 			},
 		},
 		{
+			name: "VM and container applications with duplicate host ports",
+			apps: []ApplicationProviderSpec{
+				newTestVmInlineAppWithPorts(t, "vm-app", []string{"8080:80"}),
+				newTestApplicationWithPortsAndResources(require, "container-app", "quay.io/app/image:1", []string{"8080:81"}, nil),
+			},
+			wantErrs: []string{"host port 8080/tcp is already used by application \"vm-app\""},
+		},
+		{
 			name: "invalid volume name",
 			apps: []ApplicationProviderSpec{
 				newTestApplication(require, "app1", "quay.io/app/image:1", "quay.io/vol/image:1", "vol@1"),

--- a/api/core/v1beta1/validation_test.go
+++ b/api/core/v1beta1/validation_test.go
@@ -1111,7 +1111,7 @@ func TestValidateApplications(t *testing.T) {
 			},
 		},
 		{
-			name: "VM applications with duplicate host ports",
+			name: "When VM applications publish the same host port it should reject the configuration",
 			apps: []ApplicationProviderSpec{
 				newTestVmInlineAppWithPorts(t, "app1", []string{"8080:80"}),
 				newTestVmInlineAppWithPorts(t, "app2", []string{"8080:81"}),
@@ -1119,7 +1119,7 @@ func TestValidateApplications(t *testing.T) {
 			wantErrs: []string{"host port 8080/tcp is already used by application \"app1\""},
 		},
 		{
-			name: "VM applications with duplicate host ports and explicit default protocol",
+			name: "When VM applications publish the same host port with an explicit TCP protocol it should reject the configuration",
 			apps: []ApplicationProviderSpec{
 				newTestVmInlineAppWithPorts(t, "app1", []string{"8080:80"}),
 				newTestVmInlineAppWithPorts(t, "app2", []string{"8080:81/tcp"}),
@@ -1127,14 +1127,14 @@ func TestValidateApplications(t *testing.T) {
 			wantErrs: []string{"host port 8080/tcp is already used by application \"app1\""},
 		},
 		{
-			name: "VM applications with same host port on different protocols",
+			name: "When VM applications publish the same host port on different protocols it should accept the configuration",
 			apps: []ApplicationProviderSpec{
 				newTestVmInlineAppWithPorts(t, "app1", []string{"8080:80/tcp"}),
 				newTestVmInlineAppWithPorts(t, "app2", []string{"8080:81/udp"}),
 			},
 		},
 		{
-			name: "VM and container applications with duplicate host ports",
+			name: "When VM and container applications publish the same host port it should reject the configuration",
 			apps: []ApplicationProviderSpec{
 				newTestVmInlineAppWithPorts(t, "vm-app", []string{"8080:80"}),
 				newTestApplicationWithPortsAndResources(require, "container-app", "quay.io/app/image:1", []string{"8080:81"}, nil),
@@ -1142,7 +1142,7 @@ func TestValidateApplications(t *testing.T) {
 			wantErrs: []string{"host port 8080/tcp is already used by application \"vm-app\""},
 		},
 		{
-			name: "Quadlet and VM applications with duplicate host ports",
+			name: "When Quadlet and VM applications publish the same host port it should reject the configuration",
 			apps: []ApplicationProviderSpec{
 				newTestQuadletInlineApp(t, "quadlet-app", map[string]string{
 					"app.container": "[Container]\nImage=quay.io/app/image:1\nPublishPort=8080:80",
@@ -1152,7 +1152,7 @@ func TestValidateApplications(t *testing.T) {
 			wantErrs: []string{"host port 8080/tcp is already used by application \"quadlet-app\""},
 		},
 		{
-			name: "Quadlet and VM applications with same host port on different protocols",
+			name: "When Quadlet and VM applications publish the same host port on different protocols it should accept the configuration",
 			apps: []ApplicationProviderSpec{
 				newTestQuadletInlineApp(t, "quadlet-app", map[string]string{
 					"app.container": "[Container]\nImage=quay.io/app/image:1\nPublishPort=8080:80/udp",
@@ -3334,6 +3334,11 @@ func TestValidateVmApplication(t *testing.T) {
 	}
 }
 
+func TestPublishedPortKeyRejectsInvalidGuestPort(t *testing.T) {
+	_, ok := publishedPortKey("8080:0")
+	require.False(t, ok)
+}
+
 // validVmYaml returns a minimal valid KubeVirt VirtualMachine YAML for the given name.
 func validVmYaml(name string) string {
 	return "apiVersion: kubevirt.io/v1\nkind: VirtualMachine\nmetadata:\n  name: " + name + "\nspec:\n  running: false\n"
@@ -3382,6 +3387,7 @@ func newTestVmInlineAppWithPorts(t *testing.T, name string, publishPorts []strin
 	return spec
 }
 
+// newTestQuadletInlineApp builds a Quadlet application with inline file contents.
 func newTestQuadletInlineApp(t *testing.T, name string, files map[string]string) ApplicationProviderSpec {
 	t.Helper()
 	inline := make([]ApplicationContent, 0, len(files))

--- a/api/core/v1beta1/validation_test.go
+++ b/api/core/v1beta1/validation_test.go
@@ -1142,6 +1142,25 @@ func TestValidateApplications(t *testing.T) {
 			wantErrs: []string{"host port 8080/tcp is already used by application \"vm-app\""},
 		},
 		{
+			name: "Quadlet and VM applications with duplicate host ports",
+			apps: []ApplicationProviderSpec{
+				newTestQuadletInlineApp(t, "quadlet-app", map[string]string{
+					"app.container": "[Container]\nImage=quay.io/app/image:1\nPublishPort=8080:80",
+				}),
+				newTestVmInlineAppWithPorts(t, "vm-app", []string{"8080:81"}),
+			},
+			wantErrs: []string{"host port 8080/tcp is already used by application \"quadlet-app\""},
+		},
+		{
+			name: "Quadlet and VM applications with same host port on different protocols",
+			apps: []ApplicationProviderSpec{
+				newTestQuadletInlineApp(t, "quadlet-app", map[string]string{
+					"app.container": "[Container]\nImage=quay.io/app/image:1\nPublishPort=8080:80/udp",
+				}),
+				newTestVmInlineAppWithPorts(t, "vm-app", []string{"8080:81/tcp"}),
+			},
+		},
+		{
 			name: "invalid volume name",
 			apps: []ApplicationProviderSpec{
 				newTestApplication(require, "app1", "quay.io/app/image:1", "quay.io/vol/image:1", "vol@1"),
@@ -3360,6 +3379,22 @@ func newTestVmInlineAppWithPorts(t *testing.T, name string, publishPorts []strin
 	}))
 	var spec ApplicationProviderSpec
 	require.NoError(t, spec.FromVmApplication(vm))
+	return spec
+}
+
+func newTestQuadletInlineApp(t *testing.T, name string, files map[string]string) ApplicationProviderSpec {
+	t.Helper()
+	inline := make([]ApplicationContent, 0, len(files))
+	for path, content := range files {
+		inline = append(inline, ApplicationContent{Path: path, Content: lo.ToPtr(content)})
+	}
+	quadletApp := QuadletApplication{
+		AppType: AppTypeQuadlet,
+		Name:    lo.ToPtr(name),
+	}
+	require.NoError(t, quadletApp.FromInlineApplicationProviderSpec(InlineApplicationProviderSpec{Inline: inline}))
+	var spec ApplicationProviderSpec
+	require.NoError(t, spec.FromQuadletApplication(quadletApp))
 	return spec
 }
 

--- a/api/core/v1beta1/validation_test.go
+++ b/api/core/v1beta1/validation_test.go
@@ -1111,6 +1111,29 @@ func TestValidateApplications(t *testing.T) {
 			},
 		},
 		{
+			name: "VM applications with duplicate host ports",
+			apps: []ApplicationProviderSpec{
+				newTestVmInlineAppWithPorts(t, "app1", []string{"8080:80"}),
+				newTestVmInlineAppWithPorts(t, "app2", []string{"8080:81"}),
+			},
+			wantErrs: []string{"host port 8080/tcp is already used by application \"app1\""},
+		},
+		{
+			name: "VM applications with duplicate host ports and explicit default protocol",
+			apps: []ApplicationProviderSpec{
+				newTestVmInlineAppWithPorts(t, "app1", []string{"8080:80"}),
+				newTestVmInlineAppWithPorts(t, "app2", []string{"8080:81/tcp"}),
+			},
+			wantErrs: []string{"host port 8080/tcp is already used by application \"app1\""},
+		},
+		{
+			name: "VM applications with same host port on different protocols",
+			apps: []ApplicationProviderSpec{
+				newTestVmInlineAppWithPorts(t, "app1", []string{"8080:80/tcp"}),
+				newTestVmInlineAppWithPorts(t, "app2", []string{"8080:81/udp"}),
+			},
+		},
+		{
 			name: "invalid volume name",
 			apps: []ApplicationProviderSpec{
 				newTestApplication(require, "app1", "quay.io/app/image:1", "quay.io/vol/image:1", "vol@1"),

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -825,6 +825,8 @@ To deploy a VM application, add an entry to the `applications` section of the de
 | `inline` | Required. Exactly one file named `vm.yaml`. The file must be a KubeVirt `VirtualMachine` manifest with `apiVersion: kubevirt.io/v1`, `kind: VirtualMachine`, and `metadata.name` matching the application name. |
 | `publishPorts` | Optional. List of host-to-guest port mappings. Each entry must use the format `"hostPort:guestPort"` or `"hostPort:guestPort/protocol"` (for example, `"8080:80"` or `"8080:80/tcp"`). |
 
+Published host ports are unique per device and protocol across VM and container applications. The API rejects a configuration when two applications request the same host port for the same protocol; an omitted protocol is treated as TCP.
+
 > [!NOTE]
 > The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly. You can configure a default virt-launcher image, optional per-OS images, and passt workarounds used for that conversion; see [Configuring VM application rendering](../installing/configuring-vm-render.md).
 
@@ -1695,7 +1697,7 @@ applications, quadlet definitions are the recommended approach.
   default it runs under the root podman/systemd instance. If set to a non-root user, it runs under a
   rootless podman instance for that user.
 * **Environment Variables** - Optional - Variables to be injected into the running container
-* **Port Mappings** - Optional - Must be in the format `hostPort:containerPort`, with each port limited in the range of `1-65535`
+* **Port Mappings** - Optional - Must be in the format `hostPort:containerPort[/protocol]`, with each port limited in the range of `1-65535`. Published host ports are unique per device and protocol across VM and container applications; an omitted protocol is treated as TCP.
 * **CPU Limits** - Optional - Positive decimal number (e.g., `"1.5"`, `"2"`, `"0.5"`)
 * **Memory Limits** - Optional - Number followed by optional unit - `b` (bytes), `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). Examples: `"512m"`, `"2g"`, `"1024k"`
 * **Named Volume Mounts** - Optional - Persistent volumes mounted within the container

--- a/docs/user/using/managing-devices.md
+++ b/docs/user/using/managing-devices.md
@@ -825,7 +825,7 @@ To deploy a VM application, add an entry to the `applications` section of the de
 | `inline` | Required. Exactly one file named `vm.yaml`. The file must be a KubeVirt `VirtualMachine` manifest with `apiVersion: kubevirt.io/v1`, `kind: VirtualMachine`, and `metadata.name` matching the application name. |
 | `publishPorts` | Optional. List of host-to-guest port mappings. Each entry must use the format `"hostPort:guestPort"` or `"hostPort:guestPort/protocol"` (for example, `"8080:80"` or `"8080:80/tcp"`). |
 
-Published host ports are unique per device and protocol across VM and container applications. The API rejects a configuration when two applications request the same host port for the same protocol; an omitted protocol is treated as TCP.
+Published host ports are unique per device and protocol across VM, container, and inline Quadlet `.container` applications. The API rejects a configuration when two applications request the same host port for the same protocol; an omitted protocol is treated as TCP.
 
 > [!NOTE]
 > The control plane converts the `vm.yaml` manifest into Quadlet units before the agent deploys it. The agent does not run the KubeVirt manifest directly. You can configure a default virt-launcher image, optional per-OS images, and passt workarounds used for that conversion; see [Configuring VM application rendering](../installing/configuring-vm-render.md).
@@ -1697,7 +1697,7 @@ applications, quadlet definitions are the recommended approach.
   default it runs under the root podman/systemd instance. If set to a non-root user, it runs under a
   rootless podman instance for that user.
 * **Environment Variables** - Optional - Variables to be injected into the running container
-* **Port Mappings** - Optional - Must be in the format `hostPort:containerPort[/protocol]`, with each port limited in the range of `1-65535`. Published host ports are unique per device and protocol across VM and container applications; an omitted protocol is treated as TCP.
+* **Port Mappings** - Optional - Must be in the format `hostPort:containerPort[/protocol]`, with each port limited in the range of `1-65535`. Published host ports are unique per device and protocol across VM, container, and inline Quadlet `.container` applications; an omitted protocol is treated as TCP.
 * **CPU Limits** - Optional - Positive decimal number (e.g., `"1.5"`, `"2"`, `"0.5"`)
 * **Memory Limits** - Optional - Number followed by optional unit - `b` (bytes), `k` (kibibytes), `m` (mebibytes), or `g` (gibibytes). Examples: `"512m"`, `"2g"`, `"1024k"`
 * **Named Volume Mounts** - Optional - Persistent volumes mounted within the container

--- a/test/e2e/applications/containers/containers_test.go
+++ b/test/e2e/applications/containers/containers_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Single Container Applications", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("reports error status when a second container application binds to an already used port", Label("88861", "sanity"), func() {
+	It("rejects a second container application that binds to an already used port during validation", Label("88861", "sanity"), func() {
 		By("Deploying first container application on port " + getPortMapping())
 		err := harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
 			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{defaultAppSpec}
@@ -149,16 +149,12 @@ var _ = Describe("Single Container Applications", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(containerPorts).To(ContainSubstring(hostPort), "expected host port %s to be mapped for first app", hostPort)
 
-		By("Deploying second container application on the same port")
+		By("Rejecting the second container application on the same port during validation")
 		GinkgoWriter.Printf("Deploying second container app %s on conflicting port %s\n", containerAppName2, getPortMapping())
-		err = harness.UpdateDeviceAndWaitForVersion(deviceId, func(device *v1beta1.Device) {
+		err = harness.UpdateDevice(deviceId, func(device *v1beta1.Device) {
 			device.Spec.Applications = &[]v1beta1.ApplicationProviderSpec{defaultAppSpec, samePortSecondAppSpec}
 		})
-		Expect(err).ToNot(HaveOccurred())
-
-		By("Verifying second application enters Error status due to port conflict")
-		err = harness.WaitForApplicationStatus(deviceId, containerAppName2, v1beta1.ApplicationStatusError, testutil.TIMEOUT, testutil.POLLING)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("host port %s/tcp is already used", hostPort))))
 
 		By("Verifying first application remains Running")
 		err = harness.WaitForApplicationStatus(deviceId, containerAppName, v1beta1.ApplicationStatusRunning, testutil.TIMEOUT, testutil.POLLING)


### PR DESCRIPTION
## Problem
The API accepted multiple VM applications on one device that requested the same published host port. The invalid configuration was persisted and later caused one workload to fail during runtime port binding. The same collision could also occur between a VM and a container application.

## Root Cause
Validation checked each application's port syntax and range, but did not enforce uniqueness across device applications that publish host ports.

## Fix
Track normalized published host-port/protocol bindings during validation for VM and container applications. Reject duplicates with an actionable validation error. An omitted protocol is treated as TCP; distinct protocols remain independently valid.

## Documentation
Documented device-scoped published-port uniqueness and protocol behavior in the device management guide.

## Testing
- `go test ./api/core/v1beta1 -run 'TestValidateApplications|TestValidateVmApplication' -count=1`
- `make unit-test` — 6,945 tests passed, 2 skipped
- `make build`
- `make lint`
- `make lint-docs`
- `make spellcheck-docs`
- `git diff --check`

## Confidence
High — the validation path is shared by direct device and fleet-template requests, and regression tests cover VM-to-VM and VM-to-container collisions.

## Rollback
Revert commits `704c59ccd` and `c56b78ac8` to restore the previous validation behavior.

## Risk Assessment
Low — this is a validation-only behavior change affecting conflicting VM/container published-port configurations.

Jira: EDM-5264