### PR TITLE
EDM-5046: update e2e to expect third-party greenboot rollback and add packaging regression test

### DIFF
--- a/test/e2e/agent/agent_update_test.go
+++ b/test/e2e/agent/agent_update_test.go
@@ -374,8 +374,8 @@ var _ = Describe("VM Agent behavior during updates", Label("agent-update"), func
 		})
 		It("Should rollback when third-party health check (MicroShift) fails", Label("greenboot-third-party", "88229", "agent"), func() {
 			harness := e2e.GetWorkerHarness()
-			// Shorten flightctl and MicroShift greenboot check timeouts; LONGTIMEOUT below
-			// is the outer bound for the full reboot+rollback cycle.
+			// Shorten flightctl and MicroShift greenboot check timeouts so the full
+			// reboot+rollback cycle fits within LONGTIMEOUT.
 			setFastGreenbootHealthTimeouts(harness)
 
 			By("Getting initial device state")
@@ -406,9 +406,11 @@ var _ = Describe("VM Agent behavior during updates", Label("agent-update"), func
 					device.Status.SystemInfo.BootID != initialBootID
 			}, LONGTIMEOUT)
 
+			// Volatile journal drops prior-boot logs so FALLBACK may not appear; rollback
+			// is already confirmed via device status above.
 			assertGreenbootFallbackJournalDetected(harness, true)
 
-			By("Verifying device reports as OutOfDate after rollback (spec wants v7, running initial)")
+			By("Verifying device reports OutOfDate after rollback (spec wants v7, running initial)")
 			harness.WaitForDeviceContents(deviceId, "device should be out of date after rollback", func(device *v1beta1.Device) bool {
 				if device.Status.Updated.Status != v1beta1.DeviceUpdatedStatusOutOfDate {
 					return false
@@ -794,12 +796,11 @@ func readAgentLogsForRollbackAssertion(harness *e2e.Harness) string {
 // the currently-booted deployment before triggering the v11 update also takes effect on
 // the v11 boot and the rollback boot that follows it.
 //
-// MICROSHIFT_WAIT_TIMEOUT_SEC shortens 40_microshift_running_check.sh (default 5–10m
-// per attempt) so third-party rollback e2e fits within LONGTIMEOUT.
-//
-// Existing FLIGHTCTL_HEALTH_* and MICROSHIFT_WAIT_TIMEOUT_SEC keys are stripped
-// before append so repeated calls (or a non-pristine VM) do not grow
-// greenboot.conf with duplicate assignments.
+// Existing FLIGHTCTL_HEALTH_* and MICROSHIFT_WAIT_TIMEOUT_SEC keys are stripped before
+// append so repeated calls (or a non-pristine VM) do not grow greenboot.conf with
+// duplicate assignments.
+// MICROSHIFT_WAIT_TIMEOUT_SEC shortens 40_microshift_running_check.sh (default 5-10m
+// per attempt) so the third-party rollback e2e fits within LONGTIMEOUT.
 const fastGreenbootOverrideScript = `sudo mkdir -p /etc/greenboot
 sudo touch /etc/greenboot/greenboot.conf
 sudo sed -i \

--- a/test/packaging/greenboot_revert_test.go
+++ b/test/packaging/greenboot_revert_test.go
@@ -25,6 +25,10 @@ func repoRoot(t *testing.T) string {
 	}
 }
 
+// TestGreenbootConfigureServiceRemoved is a packaging regression test that verifies
+// flightctl-configure-greenboot.service and all DISABLED_HEALTHCHECKS management have
+// been removed. The configure-greenboot service was silently disabling all third-party
+// greenboot health checks (EDM-5046); this test prevents reintroduction.
 func TestGreenbootConfigureServiceRemoved(t *testing.T) {
 	root := repoRoot(t)
 
@@ -59,6 +63,7 @@ func TestGreenbootConfigureServiceRemoved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read functions.sh: %v", err)
 	}
+	functionsText := string(functions)
 	for _, forbidden := range []string{
 		"find_third_party_scripts",
 		"find_blocked_vendor_healthchecks",
@@ -66,7 +71,7 @@ func TestGreenbootConfigureServiceRemoved(t *testing.T) {
 		"DISABLED_HEALTHCHECKS",
 		"DISABLED_VENDOR_HEALTHCHECKS",
 	} {
-		if strings.Contains(string(functions), forbidden) {
+		if strings.Contains(functionsText, forbidden) {
 			t.Fatalf("functions.sh still contains %q", forbidden)
 		}
 	}


### PR DESCRIPTION
## Summary

- Flip `greenboot-third-party` e2e test (label `88229`): MicroShift health check failure should now **trigger** OS rollback and leave device `OutOfDate` — the old test asserted the opposite (suppressed by `flightctl-configure-greenboot.service`)
- Add `MICROSHIFT_WAIT_TIMEOUT_SEC=60` to `fastGreenbootOverrideScript` so the rollback cycle fits within `LONGTIMEOUT` (MicroShift's default health check wait is 5–10 min)
- Extract `assertGreenbootFallbackJournalDetected()` helper; reuse from both the third-party test and `waitForGreenbootOSRollbackFromV11BrokenAgent`
- Add `test/packaging/greenboot_revert_test.go`: source-tree regression test that asserts `flightctl-configure-greenboot.service`, the configure script, and all `DISABLED_HEALTHCHECKS` logic are absent (passes once the packaging removals in #3537 land on main)

## Related

- Fixes EDM-5046
- Depends on #3537 (packaging removals) for `TestGreenbootConfigureServiceRemoved` to pass

## Test plan

- [ ] `go build ./test/e2e/agent/... ./test/packaging/...` — clean
- [ ] `make lint` — 0 issues
- [ ] CI e2e: `GINKGO_LABEL_FILTER=greenboot-third-party`
- [ ] After #3537 merges: `go test ./test/packaging/ -run TestGreenbootConfigureServiceRemoved`

🤖 Generated with [Claude Code](https://claude.com/claude-code)