### PR TITLE
NO-ISSUE: Avoid Helm uninstall PV reclaim race

### DIFF
--- a/.github/workflows/pr-helm-upgrade-testing.yaml
+++ b/.github/workflows/pr-helm-upgrade-testing.yaml
@@ -376,16 +376,36 @@ jobs:
             echo ""
           done
 
-          # Check for orphaned PVs that were bound to flightctl claims
-          ORPHANED_PVS=$(kubectl get pv --no-headers 2>/dev/null \
-            | { grep -E "flightctl-(external|internal)" || true; } | wc -l)
-          if [ "$ORPHANED_PVS" -ne 0 ]; then
-            echo "FAIL: $ORPHANED_PVS PV(s) referencing flightctl namespaces still exist:"
-            kubectl get pv | grep -E "flightctl-(external|internal)"
-            FAILED=true
-          else
-            echo "✓ No orphaned PVs referencing flightctl namespaces"
-          fi
+          # PVC deletion and PV reclaim are asynchronous. Give the provisioner a
+          # short window to delete released PVs before treating them as orphaned.
+          PV_RECLAIM_TIMEOUT=30
+          PV_RECLAIM_INTERVAL=2
+          PV_RECLAIM_DEADLINE=$((SECONDS + PV_RECLAIM_TIMEOUT))
+          ORPHANED_PVS=""
+
+          while true; do
+            ORPHANED_PVS=$(kubectl get pv -o json \
+              | jq -r '.items[]
+                | select(.spec.claimRef.namespace == "flightctl-external" or
+                         .spec.claimRef.namespace == "flightctl-internal")
+                | [.metadata.name, .status.phase, .spec.persistentVolumeReclaimPolicy,
+                   .spec.claimRef.namespace, .spec.claimRef.name]
+                | @tsv')
+
+            if [ -z "$ORPHANED_PVS" ]; then
+              echo "✓ No orphaned PVs referencing flightctl namespaces"
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$PV_RECLAIM_DEADLINE" ]; then
+              echo "FAIL: PV(s) referencing flightctl namespaces still exist after ${PV_RECLAIM_TIMEOUT}s:"
+              printf '%s\n' "$ORPHANED_PVS"
+              FAILED=true
+              break
+            fi
+
+            sleep "$PV_RECLAIM_INTERVAL"
+          done
 
           if [ "$FAILED" = "true" ]; then
             echo ""

--- a/.github/workflows/pr-helm-upgrade-testing.yaml
+++ b/.github/workflows/pr-helm-upgrade-testing.yaml
@@ -378,28 +378,20 @@ jobs:
 
           # PVC deletion and PV reclaim are asynchronous. Give the provisioner a
           # short window to delete released PVs before treating them as orphaned.
-          PV_RECLAIM_TIMEOUT=30
-          ORPHANED_PV_NAMES_OUTPUT=$(kubectl get pv -o jsonpath='{range .items[?(@.spec.claimRef.namespace=="flightctl-external")]}{.metadata.name}{"\n"}{end}{range .items[?(@.spec.claimRef.namespace=="flightctl-internal")]}{.metadata.name}{"\n"}{end}')
-          ORPHANED_PV_NAMES=()
-          if [ -n "$ORPHANED_PV_NAMES_OUTPUT" ]; then
-            mapfile -t ORPHANED_PV_NAMES <<< "$ORPHANED_PV_NAMES_OUTPUT"
-          fi
+          ORPHANED_PVS=""
+          for ((attempt = 1; attempt <= 10; attempt++)); do
+            PV_LIST=$(kubectl get pv --no-headers)
+            ORPHANED_PVS=$(printf '%s\n' "$PV_LIST" | grep -E "flightctl-(external|internal)" || true)
+            [ -z "$ORPHANED_PVS" ] && break
+            [ "$attempt" -lt 10 ] && sleep 1
+          done
 
-          if [ "${#ORPHANED_PV_NAMES[@]}" -eq 0 ]; then
-            echo "✓ No orphaned PVs referencing flightctl namespaces"
+          if [ -n "$ORPHANED_PVS" ]; then
+            echo "FAIL: PV(s) referencing flightctl namespaces still exist after 10s:"
+            printf '%s\n' "$ORPHANED_PVS"
+            FAILED=true
           else
-            PV_RESOURCES=()
-            for PV_NAME in "${ORPHANED_PV_NAMES[@]}"; do
-              PV_RESOURCES+=("pv/${PV_NAME}")
-            done
-
-            if kubectl wait --for=delete "${PV_RESOURCES[@]}" --timeout="${PV_RECLAIM_TIMEOUT}s"; then
-              echo "✓ No orphaned PVs referencing flightctl namespaces"
-            else
-              echo "FAIL: PV(s) referencing flightctl namespaces still exist after ${PV_RECLAIM_TIMEOUT}s:"
-              kubectl get pv "${ORPHANED_PV_NAMES[@]}" --ignore-not-found -o wide
-              FAILED=true
-            fi
+            echo "✓ No orphaned PVs referencing flightctl namespaces"
           fi
 
           if [ "$FAILED" = "true" ]; then

--- a/.github/workflows/pr-helm-upgrade-testing.yaml
+++ b/.github/workflows/pr-helm-upgrade-testing.yaml
@@ -379,33 +379,28 @@ jobs:
           # PVC deletion and PV reclaim are asynchronous. Give the provisioner a
           # short window to delete released PVs before treating them as orphaned.
           PV_RECLAIM_TIMEOUT=30
-          PV_RECLAIM_INTERVAL=2
-          PV_RECLAIM_DEADLINE=$((SECONDS + PV_RECLAIM_TIMEOUT))
-          ORPHANED_PVS=""
+          ORPHANED_PV_NAMES_OUTPUT=$(kubectl get pv -o jsonpath='{range .items[?(@.spec.claimRef.namespace=="flightctl-external")]}{.metadata.name}{"\n"}{end}{range .items[?(@.spec.claimRef.namespace=="flightctl-internal")]}{.metadata.name}{"\n"}{end}')
+          ORPHANED_PV_NAMES=()
+          if [ -n "$ORPHANED_PV_NAMES_OUTPUT" ]; then
+            mapfile -t ORPHANED_PV_NAMES <<< "$ORPHANED_PV_NAMES_OUTPUT"
+          fi
 
-          while true; do
-            ORPHANED_PVS=$(kubectl get pv -o json \
-              | jq -r '.items[]
-                | select(.spec.claimRef.namespace == "flightctl-external" or
-                         .spec.claimRef.namespace == "flightctl-internal")
-                | [.metadata.name, .status.phase, .spec.persistentVolumeReclaimPolicy,
-                   .spec.claimRef.namespace, .spec.claimRef.name]
-                | @tsv')
+          if [ "${#ORPHANED_PV_NAMES[@]}" -eq 0 ]; then
+            echo "✓ No orphaned PVs referencing flightctl namespaces"
+          else
+            PV_RESOURCES=()
+            for PV_NAME in "${ORPHANED_PV_NAMES[@]}"; do
+              PV_RESOURCES+=("pv/${PV_NAME}")
+            done
 
-            if [ -z "$ORPHANED_PVS" ]; then
+            if kubectl wait --for=delete "${PV_RESOURCES[@]}" --timeout="${PV_RECLAIM_TIMEOUT}s"; then
               echo "✓ No orphaned PVs referencing flightctl namespaces"
-              break
-            fi
-
-            if [ "$SECONDS" -ge "$PV_RECLAIM_DEADLINE" ]; then
+            else
               echo "FAIL: PV(s) referencing flightctl namespaces still exist after ${PV_RECLAIM_TIMEOUT}s:"
-              printf '%s\n' "$ORPHANED_PVS"
+              kubectl get pv "${ORPHANED_PV_NAMES[@]}" --ignore-not-found -o wide
               FAILED=true
-              break
             fi
-
-            sleep "$PV_RECLAIM_INTERVAL"
-          done
+          fi
 
           if [ "$FAILED" = "true" ]; then
             echo ""


### PR DESCRIPTION
## What

Avoid flaky Helm upgrade workflow failures caused by asynchronous PV reclaim after uninstall.

## Why

The post-delete hook deletes the Alertmanager PVC, but the storage provisioner may leave its `Released` PV visible briefly after Helm returns. The existing one-shot check fails during that window.

## Change

- Poll exact `claimRef.namespace` matches for up to 30 seconds.
- Check every 2 seconds, so successful cleanup still proceeds immediately.
- Preserve failure for PVs that remain after the timeout.

## Validation

- `git diff --check`
- Embedded workflow shell block passes `bash -n`.
- jq filter verified against representative PV JSON.

Fixes the cleanup flakiness seen in the Helm upgrade workflow.